### PR TITLE
feat(scene): Scene Tutorial feature parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ nix develop
 # manually find the datoviz include path in LD_LIBRARY_PATH and run these two commands for now
 glslc -o mandelbrot.frag.spv mandelbrot.frag
 glslc -o mandelbrot.vert.spv mandelbrot.vert -I /nix/store/fsdinc3ikljgf7rbrvc1abyh9421p1mh-datoviz/include/datoviz/glsl/
-cabal repl
-mandelbrot
+cabal run mandelbrot
 ```
 

--- a/datoviz-hs.cabal
+++ b/datoviz-hs.cabal
@@ -65,6 +65,7 @@ library
                       Graphics.Datoviz.Colormaps
                       Graphics.Datoviz.Panel
                       Graphics.Datoviz.Scene
+                      Graphics.Datoviz.Types
                       Graphics.Datoviz.Vklite
                       Graphics.Datoviz.Visuals
 
@@ -87,8 +88,18 @@ library
     -- Base language which the package is written in.
     default-language: Haskell2010
 
+executable mandelbrot
+    import:           warnings
+    other-modules:    Mandelbrot.Internal
+    main-is:          Mandelbrot.hs
+    hs-source-dirs:   examples
+    build-depends:    base ^>=4.16.3.0
+                    , datoviz-hs
+                    , random
+                    , vector
+    default-language: Haskell2010
+
 executable standalone-canvas
-    -- import common warning flags.
     import:           warnings
     main-is:          StandaloneCanvas.hs
     hs-source-dirs:   examples

--- a/datoviz-hs.cabal
+++ b/datoviz-hs.cabal
@@ -60,6 +60,13 @@ library
 
     -- Modules exported by the library.
     exposed-modules:  Graphics.Datoviz
+                      Graphics.Datoviz.App
+                      Graphics.Datoviz.Canvas
+                      Graphics.Datoviz.Colormaps
+                      Graphics.Datoviz.Panel
+                      Graphics.Datoviz.Scene
+                      Graphics.Datoviz.Vklite
+                      Graphics.Datoviz.Visuals
 
     -- Modules included in this library but not exported.
     -- other-modules:
@@ -72,9 +79,21 @@ library
 
     -- Other library packages from which modules are imported.
     build-depends:    base ^>=4.16.3.0
+                    , vector
 
     -- Directories containing source files.
     hs-source-dirs:   src
 
     -- Base language which the package is written in.
+    default-language: Haskell2010
+
+executable standalone-canvas
+    -- import common warning flags.
+    import:           warnings
+    main-is:          StandaloneCanvas.hs
+    hs-source-dirs:   examples
+    build-depends:    base ^>=4.16.3.0
+                    , datoviz-hs
+                    , random
+                    , vector
     default-language: Haskell2010

--- a/datoviz-hs.cabal
+++ b/datoviz-hs.cabal
@@ -80,6 +80,7 @@ library
 
     -- Other library packages from which modules are imported.
     build-depends:    base ^>=4.16.3.0
+                    , linear
                     , vector
 
     -- Directories containing source files.
@@ -105,6 +106,7 @@ executable standalone-canvas
     hs-source-dirs:   examples
     build-depends:    base ^>=4.16.3.0
                     , datoviz-hs
+                    , linear
                     , random
                     , vector
     default-language: Haskell2010

--- a/examples/Mandelbrot.hs
+++ b/examples/Mandelbrot.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import Mandelbrot.Internal
+
+main :: IO ()
+main = mandelbrot
+

--- a/examples/Mandelbrot/Internal.hsc
+++ b/examples/Mandelbrot/Internal.hsc
@@ -1,32 +1,11 @@
-{-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE PatternSynonyms #-}
+module Mandelbrot.Internal where
 
-module Graphics.Datoviz
-( module Graphics.Datoviz
-, module Graphics.Datoviz.App
-, module Graphics.Datoviz.Canvas
-, module Graphics.Datoviz.Scene
-, module Graphics.Datoviz.Visuals
-, module Graphics.Datoviz.Vklite
-) where
+#include <vulkan/vulkan_core.h>
 
-import Control.Exception
 import Foreign.C
 import Foreign.Marshal.Array
 import Foreign.Ptr
-
-import Graphics.Datoviz.App
-import Graphics.Datoviz.Canvas
-import Graphics.Datoviz.Scene
-import Graphics.Datoviz.Visuals
-import Graphics.Datoviz.Vklite
-
--- eventually we should move this out so this export becomes 'pure' haskell
-#include <vulkan/vulkan_core.h>
-
--- | Create a DvzApp with a provided backend.
-withDvzApp :: DvzBackend -> (DvzApp -> IO a) -> IO a
-withDvzApp backend = bracket (dvz_app backend) dvz_app_destroy
+import Graphics.Datoviz
 
 mandelbrot :: IO ()
 mandelbrot = withDvzApp DVZ_BACKEND_GLFW $ \app -> do
@@ -50,4 +29,3 @@ mandelbrot = withDvzApp DVZ_BACKEND_GLFW $ \app -> do
       withArray vertices $ \a -> do
         dvz_visual_data_source visual DVZ_SOURCE_TYPE_VERTEX 0 0 4 4 (castPtr a)
         dvz_app_run app 0
-

--- a/examples/StandaloneCanvas.hs
+++ b/examples/StandaloneCanvas.hs
@@ -1,0 +1,38 @@
+module Main where
+
+import Graphics.Datoviz
+
+main :: IO ()
+main = do
+    -- We create a singleton application with the GLFW backend.
+    withDvzApp DVZ_BACKEND_GLFW $ \app -> do
+        -- Get the best GPU for the job.
+        gpu <- dvz_gpu_best app
+
+        -- Create a canvas with a specified size.
+        canvas <- dvz_canvas gpu 2560 1440 0
+
+        -- We use a white background color (RGB floating-point values in [0, 1]).
+        dvz_canvas_clear_color canvas 1 1 1
+
+        -- We create a scene, which allows us to define several subplots (panels) organized within a
+        -- grid. Here, we just use a single panel spanning the entire canvas.
+        scene <- dvz_scene canvas 1 1
+
+        -- We get the panel at row 0, column 0, and we initialize it with an axes 2D controller.
+        -- The last argument is for optional flags.
+        panel <- dvz_scene_panel scene 0 0 DVZ_CONTROLLER_AXES_2D 0
+
+        -- We add a new "marker" visual in the panel.
+        -- The last argument is for optional flag
+        visual <- dvz_scene_visual panel  DVZ_VISUAL_MARKER 0
+
+        -- visual data (we don't do for-loops here)
+        --
+        -- todo
+        let n = 10000
+            pos = undefined
+            color = undefined
+            size = undefined
+        mapM_ (\(p, d) -> dvz_visual_data visual p 0 n d) [(DVZ_PROP_POS, pos), (DVZ_PROP_COLOR, color), (DVZ_PROP_MARKER_SIZE, size)]
+        dvz_app_run app 0

--- a/examples/StandaloneCanvas.hs
+++ b/examples/StandaloneCanvas.hs
@@ -4,6 +4,8 @@ module Main where
 import qualified Data.Vector.Storable as VS
 import Graphics.Datoviz
 
+import qualified Linear.V3 as L
+
 foreign import capi unsafe "datoviz/datoviz.h" dvz_rand_normal :: IO Float
 foreign import capi unsafe "datoviz/datoviz.h" dvz_rand_float :: IO Float
 
@@ -48,16 +50,14 @@ mkPosVec n = VS.generateM n go
         go _ = do
             z <- dvz_rand_normal
             o <- dvz_rand_normal
-            pure $ (DVec3 . FsVec) $ VS.fromList (fmap realToFrac [z, o, 0.0])
+            pure $ DVec3 (fmap realToFrac (L.V3 z o 0.0))
 
 mkColorVec :: Int -> IO (VS.Vector CVec4)
 mkColorVec n = VS.generateM n go
     where
         go _ = do
-            let v = (CVec4 . FsVec) $ VS.fromList [0, 0, 0, 0]
             c <- dvz_rand_float
-            dvz_colormap_scale DVZ_CMAP_VIRIDIS (realToFrac c) 0 1 v
-            pure v
+            dvz_colormap_scale DVZ_CMAP_VIRIDIS (realToFrac c) 0 1
 
 mkSizeVec :: Int -> IO (VS.Vector Float)
 mkSizeVec n = VS.generateM n go

--- a/examples/StandaloneCanvas.hs
+++ b/examples/StandaloneCanvas.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE CApiFFI #-}
 module Main where
 
+import Data.Word
+
 import Graphics.Datoviz
+import Foreign (Ptr)
+
+foreign import capi unsafe "datoviz/datoviz.h" dvz_rand_normal :: IO Float
+foreign import capi unsafe "datoviz/datoviz.h" dvz_rand_float :: IO Float
 
 main :: IO ()
 main = do
@@ -27,12 +34,20 @@ main = do
         -- The last argument is for optional flag
         visual <- dvz_scene_visual panel  DVZ_VISUAL_MARKER 0
 
-        -- visual data (we don't do for-loops here)
-        --
-        -- todo
+        -- visual data but we don't do for-loops here
         let n = 10000
-            pos = undefined
-            color = undefined
-            size = undefined
+        pos <- mkPosVec n
+        size <- mkSizeVec n
+        color <- mkColorVec n
         mapM_ (\(p, d) -> dvz_visual_data visual p 0 n d) [(DVZ_PROP_POS, pos), (DVZ_PROP_COLOR, color), (DVZ_PROP_MARKER_SIZE, size)]
         dvz_app_run app 0
+
+mkColorVec :: Word32 -> IO (Ptr DVe)
+mkColorVec n = do
+
+
+mkSizeVec :: Word32 -> IO (Ptr ())
+mkSizeVec n = undefined
+
+mkPosVec :: Word32 -> IO (Ptr ())
+mkPosVec n = undefined

--- a/examples/StandaloneCanvas.hs
+++ b/examples/StandaloneCanvas.hs
@@ -48,13 +48,13 @@ mkPosVec n = VS.generateM n go
         go _ = do
             z <- dvz_rand_normal
             o <- dvz_rand_normal
-            pure $ FsVec $ VS.fromList (fmap realToFrac [z, o, 0.0])
+            pure $ (DVec3 . FsVec) $ VS.fromList (fmap realToFrac [z, o, 0.0])
 
 mkColorVec :: Int -> IO (VS.Vector CVec4)
 mkColorVec n = VS.generateM n go
     where
         go _ = do
-            let v = FsVec $ VS.fromList [0, 0, 0, 0]
+            let v = (CVec4 . FsVec) $ VS.fromList [0, 0, 0, 0]
             c <- dvz_rand_float
             dvz_colormap_scale DVZ_CMAP_VIRIDIS (realToFrac c) 0 1 v
             pure v

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
           , cglm
           , glfw
           , lib
+          , linear
           , random
           , shaderc
           , vector
@@ -61,6 +62,7 @@
             libraryHaskellDepends =
               [
                 base
+                linear
                 random
                 vector
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Almost raw Haskell bindings to libgccjit.";
+  description = "Almost raw Haskell bindings to datoviz.";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
@@ -47,7 +47,9 @@
           , cglm
           , glfw
           , lib
+          , random
           , shaderc
+          , vector
           , vulkan-headers
           , vulkan-loader
           , xorg
@@ -59,14 +61,16 @@
             libraryHaskellDepends =
               [
                 base
+                random
+                vector
               ];
-            librarySystemDepends = 
+            librarySystemDepends =
             [
               cglm datoviz glfw shaderc vulkan-headers vulkan-loader
               # xorg.libX11 xorg.libXrandr xorg.libXinerama xorg.libXcursor
               # xorg.libXi xorg.libXau xorg.libXdmcp xorg.libXrender xorg.libXfixes
             ];
-            description = "Almost raw Haskell bindings to libgccjit.";
+            description = "Almost raw Haskell bindings to datoviz.";
             license = "unknown";
             hydraPlatforms = lib.platforms.none;
           };

--- a/src/Graphics/Datoviz.hs
+++ b/src/Graphics/Datoviz.hs
@@ -1,7 +1,11 @@
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Use camelCase" #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 module Graphics.Datoviz
 ( module Graphics.Datoviz
 , module Graphics.Datoviz.App
 , module Graphics.Datoviz.Canvas
+, module Graphics.Datoviz.Colormaps
 , module Graphics.Datoviz.Scene
 , module Graphics.Datoviz.Types
 , module Graphics.Datoviz.Visuals
@@ -9,14 +13,34 @@ module Graphics.Datoviz
 ) where
 
 import Control.Exception
+import Data.Vector.Storable qualified as VS
+import Data.Word
+
+import Foreign (Storable, withForeignPtr, castPtr)
 
 import Graphics.Datoviz.App
 import Graphics.Datoviz.Canvas
+import Graphics.Datoviz.Colormaps
 import Graphics.Datoviz.Scene
 import Graphics.Datoviz.Types
 import Graphics.Datoviz.Visuals
 import Graphics.Datoviz.Vklite
+import Data.Coerce (coerce)
 
 -- | Create a DvzApp with a provided backend.
 withDvzApp :: DvzBackend -> (DvzApp -> IO a) -> IO a
 withDvzApp backend = bracket (dvz_app backend) dvz_app_destroy
+
+dvz_colormap_scale :: DvzColorMap -> Double -> Double -> Double -> CVec4 -> IO ()
+dvz_colormap_scale d x y z v = do
+    -- we need to help out the typechecker here.
+    let cv = (coerce v :: VS.Vector Word8)
+    withForeignPtr (fst $ VS.unsafeToForeignPtr0 cv) $ \v' -> do
+        c_dvz_colormap_scale d x y z (castPtr v')
+
+-- c_dvz_visual_data :: DvzVisual -> DvzPropType -> Word32 -> Word32 -> Ptr () -> IO ()
+dvz_visual_data :: Storable a => DvzVisual -> DvzPropType -> Word32 -> Word32 -> VS.Vector a -> IO ()
+dvz_visual_data dv p i c v =
+    withForeignPtr (fst $ VS.unsafeToForeignPtr0 v) $ \d'-> do
+        c_dvz_visual_data dv p i c (castPtr d')
+

--- a/src/Graphics/Datoviz.hs
+++ b/src/Graphics/Datoviz.hs
@@ -33,7 +33,7 @@ withDvzApp backend = bracket (dvz_app backend) dvz_app_destroy
 
 dvz_colormap_scale :: DvzColorMap -> Double -> Double -> Double -> CVec4 -> IO ()
 dvz_colormap_scale d x y z v = do
-    -- we need to help out the typechecker here.
+    -- we need to help out the typechecker here to unwrap our newtype.
     let cv = (coerce v :: VS.Vector Word8)
     withForeignPtr (fst $ VS.unsafeToForeignPtr0 cv) $ \v' -> do
         c_dvz_colormap_scale d x y z (castPtr v')

--- a/src/Graphics/Datoviz.hs
+++ b/src/Graphics/Datoviz.hs
@@ -1,0 +1,22 @@
+module Graphics.Datoviz
+( module Graphics.Datoviz
+, module Graphics.Datoviz.App
+, module Graphics.Datoviz.Canvas
+, module Graphics.Datoviz.Scene
+, module Graphics.Datoviz.Types
+, module Graphics.Datoviz.Visuals
+, module Graphics.Datoviz.Vklite
+) where
+
+import Control.Exception
+
+import Graphics.Datoviz.App
+import Graphics.Datoviz.Canvas
+import Graphics.Datoviz.Scene
+import Graphics.Datoviz.Types
+import Graphics.Datoviz.Visuals
+import Graphics.Datoviz.Vklite
+
+-- | Create a DvzApp with a provided backend.
+withDvzApp :: DvzBackend -> (DvzApp -> IO a) -> IO a
+withDvzApp backend = bracket (dvz_app backend) dvz_app_destroy

--- a/src/Graphics/Datoviz.hsc
+++ b/src/Graphics/Datoviz.hsc
@@ -1,168 +1,32 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE PatternSynonyms #-}
 
-module Graphics.Datoviz where
+module Graphics.Datoviz
+( module Graphics.Datoviz
+, module Graphics.Datoviz.App
+, module Graphics.Datoviz.Canvas
+, module Graphics.Datoviz.Scene
+, module Graphics.Datoviz.Visuals
+, module Graphics.Datoviz.Vklite
+) where
 
 import Control.Exception
-import Data.Word
 import Foreign.C
 import Foreign.Marshal.Array
 import Foreign.Ptr
 
-#include <datoviz/datoviz.h>
+import Graphics.Datoviz.App
+import Graphics.Datoviz.Canvas
+import Graphics.Datoviz.Scene
+import Graphics.Datoviz.Visuals
+import Graphics.Datoviz.Vklite
 
-data C_DvzApp
+-- eventually we should move this out so this export becomes 'pure' haskell
+#include <vulkan/vulkan_core.h>
 
-newtype DvzApp = DvzApp { getDvzApp :: Ptr C_DvzApp }
-
-newtype DvzBackend = DvzBackend { getDvzBackend :: CInt }
-
-pattern DVZ_BACKEND_NONE :: DvzBackend
-pattern DVZ_BACKEND_NONE = DvzBackend #{const DVZ_BACKEND_NONE}
-
-pattern DVZ_BACKEND_GLFW :: DvzBackend
-pattern DVZ_BACKEND_GLFW = DvzBackend #{const DVZ_BACKEND_GLFW}
-
-pattern DVZ_BACKEND_OFFSCREEN :: DvzBackend
-pattern DVZ_BACKEND_OFFSCREEN = DvzBackend #{const DVZ_BACKEND_OFFSCREEN}
-{-# COMPLETE DVZ_BACKEND_NONE, DVZ_BACKEND_GLFW, DVZ_BACKEND_OFFSCREEN #-}
-
-foreign import ccall dvz_app :: DvzBackend -> IO DvzApp
-
-foreign import ccall dvz_app_run :: DvzApp -> Word64 -> IO ()
-
-foreign import ccall dvz_app_destroy :: DvzApp -> IO ()
-
+-- | Create a DvzApp with a provided backend.
 withDvzApp :: DvzBackend -> (DvzApp -> IO a) -> IO a
 withDvzApp backend = bracket (dvz_app backend) dvz_app_destroy
-
-data C_DvzGpu
-
-newtype DvzGpu = DvzGpu { getDvzGpu :: Ptr C_DvzGpu }
-
-foreign import ccall dvz_gpu_best :: DvzApp -> IO DvzGpu
-
-data C_DvzCanvas
-
-newtype DvzCanvas = DvzCanvas { getDvzCanvas :: Ptr C_DvzCanvas }
-
-foreign import ccall dvz_canvas :: DvzGpu -> Word32 -> Word32 -> CInt -> IO DvzCanvas
-
-data C_DvzScene
-
-newtype DvzScene = DvzScene { getDvzScene :: Ptr C_DvzScene }
-
-foreign import ccall dvz_scene :: DvzCanvas -> Word32 -> Word32 -> IO DvzScene
-
-data C_DvzPanel
-
-newtype DvzPanel = DvzPanel { getDvzPanel :: Ptr C_DvzPanel }
-
-newtype DvzControllerType = DvzControllerType { getDvzControllerType :: CInt }
-
-pattern DVZ_CONTROLLER_NONE :: DvzControllerType
-pattern DVZ_CONTROLLER_NONE = DvzControllerType #{const DVZ_CONTROLLER_NONE}
-
-pattern DVZ_CONTROLLER_PANZOOM :: DvzControllerType
-pattern DVZ_CONTROLLER_PANZOOM = DvzControllerType #{const DVZ_CONTROLLER_PANZOOM}
-
-pattern DVZ_CONTROLLER_AXES_2D :: DvzControllerType
-pattern DVZ_CONTROLLER_AXES_2D = DvzControllerType #{const DVZ_CONTROLLER_AXES_2D}
-
-pattern DVZ_CONTROLLER_ARCBALL :: DvzControllerType
-pattern DVZ_CONTROLLER_ARCBALL = DvzControllerType #{const DVZ_CONTROLLER_ARCBALL}
-
-pattern DVZ_CONTROLLER_CAMERA :: DvzControllerType
-pattern DVZ_CONTROLLER_CAMERA = DvzControllerType #{const DVZ_CONTROLLER_CAMERA}
-
-pattern DVZ_CONTROLLER_AXES_3D :: DvzControllerType
-pattern DVZ_CONTROLLER_AXES_3D = DvzControllerType #{const DVZ_CONTROLLER_AXES_3D}
-{-# COMPLETE DVZ_CONTROLLER_NONE, DVZ_CONTROLLER_PANZOOM, DVZ_CONTROLLER_AXES_2D
-  , DVZ_CONTROLLER_ARCBALL, DVZ_CONTROLLER_CAMERA, DVZ_CONTROLLER_AXES_3D #-}
-
-foreign import ccall dvz_scene_panel :: DvzScene -> Word32 -> Word32 -> DvzControllerType -> CInt -> IO DvzPanel
-
-data C_DvzVisual
-
-newtype DvzVisual = DvzVisual { getDvzVisual :: Ptr C_DvzVisual }
-
-foreign import ccall dvz_blank_visual :: DvzScene -> CInt -> IO DvzVisual
-
-data C_DvzGraphics
-
-newtype DvzGraphics = DvzGraphics { getDvzGraphics :: Ptr C_DvzGraphics }
-
-foreign import ccall dvz_blank_graphics :: DvzScene -> CInt -> IO DvzGraphics
-
-foreign import ccall dvz_graphics_shader :: DvzGraphics -> CInt -> CString -> IO ()
-
-foreign import ccall dvz_graphics_topology :: DvzGraphics -> CInt -> IO ()
-
-foreign import ccall dvz_graphics_vertex_binding :: DvzGraphics -> Word32 -> Word64 -> IO ()
-
-foreign import ccall dvz_graphics_vertex_attr :: DvzGraphics -> Word32 -> Word32 -> CInt -> Word64 -> IO ()
-
-foreign import ccall dvz_custom_graphics :: DvzVisual -> DvzGraphics -> IO ()
-
-foreign import ccall dvz_graphics_create :: DvzGraphics -> IO ()
-
-foreign import ccall dvz_custom_visual :: DvzPanel -> DvzVisual -> IO ()
-
-newtype DvzSourceType = DvzSourceType { getDvzSourceType :: CInt }
-
-pattern DVZ_SOURCE_TYPE_NONE :: DvzSourceType
-pattern DVZ_SOURCE_TYPE_NONE = DvzSourceType #{const DVZ_SOURCE_TYPE_NONE}
-
-pattern DVZ_SOURCE_TYPE_MVP :: DvzSourceType
-pattern DVZ_SOURCE_TYPE_MVP = DvzSourceType #{const DVZ_SOURCE_TYPE_MVP}
-
-pattern DVZ_SOURCE_TYPE_VIEWPORT :: DvzSourceType
-pattern DVZ_SOURCE_TYPE_VIEWPORT = DvzSourceType #{const DVZ_SOURCE_TYPE_VIEWPORT}
-
-pattern DVZ_SOURCE_TYPE_PARAM :: DvzSourceType
-pattern DVZ_SOURCE_TYPE_PARAM = DvzSourceType #{const DVZ_SOURCE_TYPE_PARAM}
-
-pattern DVZ_SOURCE_TYPE_VERTEX :: DvzSourceType
-pattern DVZ_SOURCE_TYPE_VERTEX = DvzSourceType #{const DVZ_SOURCE_TYPE_VERTEX}
-
-pattern DVZ_SOURCE_TYPE_INDEX :: DvzSourceType
-pattern DVZ_SOURCE_TYPE_INDEX = DvzSourceType #{const DVZ_SOURCE_TYPE_INDEX}
-
-pattern DVZ_SOURCE_TYPE_IMAGE :: DvzSourceType
-pattern DVZ_SOURCE_TYPE_IMAGE = DvzSourceType #{const DVZ_SOURCE_TYPE_IMAGE}
-
-pattern DVZ_SOURCE_TYPE_VOLUME :: DvzSourceType
-pattern DVZ_SOURCE_TYPE_VOLUME = DvzSourceType #{const DVZ_SOURCE_TYPE_VOLUME}
-
-pattern DVZ_SOURCE_TYPE_TRANSFER :: DvzSourceType
-pattern DVZ_SOURCE_TYPE_TRANSFER = DvzSourceType #{const DVZ_SOURCE_TYPE_TRANSFER}
-
-pattern DVZ_SOURCE_TYPE_COLOR_TEXTURE :: DvzSourceType
-pattern DVZ_SOURCE_TYPE_COLOR_TEXTURE = DvzSourceType #{const DVZ_SOURCE_TYPE_COLOR_TEXTURE}
-
-pattern DVZ_SOURCE_TYPE_FONT_ATLAS :: DvzSourceType
-pattern DVZ_SOURCE_TYPE_FONT_ATLAS = DvzSourceType #{const DVZ_SOURCE_TYPE_FONT_ATLAS}
-
-pattern DVZ_SOURCE_TYPE_OTHER :: DvzSourceType
-pattern DVZ_SOURCE_TYPE_OTHER = DvzSourceType #{const DVZ_SOURCE_TYPE_OTHER}
-
-pattern DVZ_SOURCE_TYPE_COUNT :: DvzSourceType
-pattern DVZ_SOURCE_TYPE_COUNT = DvzSourceType #{const DVZ_SOURCE_TYPE_COUNT}
-
-{-# COMPLETE DVZ_SOURCE_TYPE_NONE,
-              DVZ_SOURCE_TYPE_MVP,
-              DVZ_SOURCE_TYPE_VIEWPORT,
-              DVZ_SOURCE_TYPE_PARAM,
-              DVZ_SOURCE_TYPE_VERTEX,
-              DVZ_SOURCE_TYPE_INDEX,
-              DVZ_SOURCE_TYPE_IMAGE,
-              DVZ_SOURCE_TYPE_VOLUME,
-              DVZ_SOURCE_TYPE_TRANSFER,
-              DVZ_SOURCE_TYPE_COLOR_TEXTURE,
-              DVZ_SOURCE_TYPE_FONT_ATLAS,
-              DVZ_SOURCE_TYPE_OTHER,
-              DVZ_SOURCE_TYPE_COUNT #-}
-
-foreign import ccall dvz_visual_data_source :: DvzVisual -> DvzSourceType -> Word32 -> Word32 -> Word32 -> Word32 -> Ptr () -> IO ()
 
 mandelbrot :: IO ()
 mandelbrot = withDvzApp DVZ_BACKEND_GLFW $ \app -> do

--- a/src/Graphics/Datoviz/App.hsc
+++ b/src/Graphics/Datoviz/App.hsc
@@ -1,0 +1,30 @@
+{-# LANGUAGE PatternSynonyms #-}
+module Graphics.Datoviz.App where
+
+import Data.Word
+import Foreign.Ptr
+import Foreign.C.Types
+
+#include <datoviz/datoviz.h>
+
+data C_DvzApp
+
+newtype DvzApp = DvzApp { getDvzApp :: Ptr C_DvzApp }
+
+newtype DvzBackend = DvzBackend { getDvzBackend :: CInt }
+
+pattern DVZ_BACKEND_NONE :: DvzBackend
+pattern DVZ_BACKEND_NONE = DvzBackend #{const DVZ_BACKEND_NONE}
+
+pattern DVZ_BACKEND_GLFW :: DvzBackend
+pattern DVZ_BACKEND_GLFW = DvzBackend #{const DVZ_BACKEND_GLFW}
+
+pattern DVZ_BACKEND_OFFSCREEN :: DvzBackend
+pattern DVZ_BACKEND_OFFSCREEN = DvzBackend #{const DVZ_BACKEND_OFFSCREEN}
+{-# COMPLETE DVZ_BACKEND_NONE, DVZ_BACKEND_GLFW, DVZ_BACKEND_OFFSCREEN #-}
+
+foreign import ccall dvz_app :: DvzBackend -> IO DvzApp
+
+foreign import ccall dvz_app_run :: DvzApp -> Word64 -> IO ()
+
+foreign import ccall dvz_app_destroy :: DvzApp -> IO ()

--- a/src/Graphics/Datoviz/Canvas.hsc
+++ b/src/Graphics/Datoviz/Canvas.hsc
@@ -1,0 +1,15 @@
+{-# LANGUAGE CApiFFI #-}
+module Graphics.Datoviz.Canvas where
+
+import Data.Word
+import Foreign.Ptr
+import Foreign.C.Types
+import Graphics.Datoviz.Vklite
+
+data C_DvzCanvas
+
+newtype DvzCanvas = DvzCanvas { getDvzCanvas :: Ptr C_DvzCanvas }
+
+foreign import ccall dvz_canvas :: DvzGpu -> Word32 -> Word32 -> CInt -> IO DvzCanvas
+
+foreign import capi safe "datoviz/datoviz.h" dvz_canvas_clear_color :: DvzCanvas -> CFloat -> CFloat -> CFloat -> IO ()

--- a/src/Graphics/Datoviz/Colormaps.hsc
+++ b/src/Graphics/Datoviz/Colormaps.hsc
@@ -2,7 +2,9 @@
 {-# LANGUAGE PatternSynonyms #-}
 module Graphics.Datoviz.Colormaps where
 
+import Foreign.Ptr
 import Foreign.C.Types
+import Graphics.Datoviz.Types
 
 #include <datoviz/datoviz.h>
 
@@ -448,6 +450,6 @@ pattern DVZ_CPAL032_COLORBLIND8 = DvzColorMap #{const DVZ_CPAL032_COLORBLIND8}
     DVZ_CPAL032_COLORBLIND8
     #-}
 
--- foreign import capi safe "datoviz/datoviz.h" dvz_colormap_scale
---     :: DvzColorMap -> Double -> Double -> Double -> CVec4 -> IO ()
+foreign import capi safe "datoviz/datoviz.h dvz_colormap_scale" c_dvz_colormap_scale
+    :: DvzColorMap -> Double -> Double -> Double -> Ptr () -> IO ()
 

--- a/src/Graphics/Datoviz/Colormaps.hsc
+++ b/src/Graphics/Datoviz/Colormaps.hsc
@@ -4,7 +4,6 @@ module Graphics.Datoviz.Colormaps where
 
 import Foreign.Ptr
 import Foreign.C.Types
-import Graphics.Datoviz.Types
 
 #include <datoviz/datoviz.h>
 

--- a/src/Graphics/Datoviz/Colormaps.hsc
+++ b/src/Graphics/Datoviz/Colormaps.hsc
@@ -1,0 +1,453 @@
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE PatternSynonyms #-}
+module Graphics.Datoviz.Colormaps where
+
+import Foreign.C.Types
+
+#include <datoviz/datoviz.h>
+
+newtype DvzColorMap = DvzColorMap { getDvzColorMap :: CInt }
+
+-- Yes, this was a vim macro.
+pattern DVZ_CMAP_BINARY :: DvzColorMap
+pattern DVZ_CMAP_BINARY = DvzColorMap #{const DVZ_CMAP_BINARY}
+pattern DVZ_CMAP_HSV :: DvzColorMap
+pattern DVZ_CMAP_HSV = DvzColorMap #{const DVZ_CMAP_HSV}
+pattern DVZ_CMAP_CIVIDIS :: DvzColorMap
+pattern DVZ_CMAP_CIVIDIS = DvzColorMap #{const DVZ_CMAP_CIVIDIS}
+pattern DVZ_CMAP_INFERNO :: DvzColorMap
+pattern DVZ_CMAP_INFERNO = DvzColorMap #{const DVZ_CMAP_INFERNO}
+pattern DVZ_CMAP_MAGMA :: DvzColorMap
+pattern DVZ_CMAP_MAGMA = DvzColorMap #{const DVZ_CMAP_MAGMA}
+pattern DVZ_CMAP_PLASMA :: DvzColorMap
+pattern DVZ_CMAP_PLASMA = DvzColorMap #{const DVZ_CMAP_PLASMA}
+pattern DVZ_CMAP_VIRIDIS :: DvzColorMap
+pattern DVZ_CMAP_VIRIDIS = DvzColorMap #{const DVZ_CMAP_VIRIDIS}
+pattern DVZ_CMAP_BLUES :: DvzColorMap
+pattern DVZ_CMAP_BLUES = DvzColorMap #{const DVZ_CMAP_BLUES}
+pattern DVZ_CMAP_BUGN :: DvzColorMap
+pattern DVZ_CMAP_BUGN = DvzColorMap #{const DVZ_CMAP_BUGN}
+pattern DVZ_CMAP_BUPU :: DvzColorMap
+pattern DVZ_CMAP_BUPU = DvzColorMap #{const DVZ_CMAP_BUPU}
+pattern DVZ_CMAP_GNBU :: DvzColorMap
+pattern DVZ_CMAP_GNBU = DvzColorMap #{const DVZ_CMAP_GNBU}
+pattern DVZ_CMAP_GREENS :: DvzColorMap
+pattern DVZ_CMAP_GREENS = DvzColorMap #{const DVZ_CMAP_GREENS}
+pattern DVZ_CMAP_GREYS :: DvzColorMap
+pattern DVZ_CMAP_GREYS = DvzColorMap #{const DVZ_CMAP_GREYS }
+pattern DVZ_CMAP_ORANGES :: DvzColorMap
+pattern DVZ_CMAP_ORANGES = DvzColorMap #{const DVZ_CMAP_ORANGES}
+pattern DVZ_CMAP_ORRD :: DvzColorMap
+pattern DVZ_CMAP_ORRD = DvzColorMap #{const DVZ_CMAP_ORRD}
+pattern DVZ_CMAP_PUBU :: DvzColorMap
+pattern DVZ_CMAP_PUBU = DvzColorMap #{const DVZ_CMAP_PUBU}
+pattern DVZ_CMAP_PUBUGN :: DvzColorMap
+pattern DVZ_CMAP_PUBUGN = DvzColorMap #{const DVZ_CMAP_PUBUGN}
+pattern DVZ_CMAP_PURPLES :: DvzColorMap
+pattern DVZ_CMAP_PURPLES = DvzColorMap #{const DVZ_CMAP_PURPLES }
+pattern DVZ_CMAP_RDPU :: DvzColorMap
+pattern DVZ_CMAP_RDPU = DvzColorMap #{const DVZ_CMAP_RDPU}
+pattern DVZ_CMAP_REDS :: DvzColorMap
+pattern DVZ_CMAP_REDS = DvzColorMap #{const DVZ_CMAP_REDS}
+pattern DVZ_CMAP_YLGN :: DvzColorMap
+pattern DVZ_CMAP_YLGN = DvzColorMap #{const DVZ_CMAP_YLGN}
+pattern DVZ_CMAP_YLGNBU :: DvzColorMap
+pattern DVZ_CMAP_YLGNBU = DvzColorMap #{const DVZ_CMAP_YLGNBU}
+pattern DVZ_CMAP_YLORBR :: DvzColorMap
+pattern DVZ_CMAP_YLORBR = DvzColorMap #{const DVZ_CMAP_YLORBR}
+pattern DVZ_CMAP_YLORRD :: DvzColorMap
+pattern DVZ_CMAP_YLORRD = DvzColorMap #{const DVZ_CMAP_YLORRD}
+pattern DVZ_CMAP_AFMHOT :: DvzColorMap
+pattern DVZ_CMAP_AFMHOT = DvzColorMap #{const DVZ_CMAP_AFMHOT}
+pattern DVZ_CMAP_AUTUMN :: DvzColorMap
+pattern DVZ_CMAP_AUTUMN = DvzColorMap #{const DVZ_CMAP_AUTUMN}
+pattern DVZ_CMAP_BONE :: DvzColorMap
+pattern DVZ_CMAP_BONE = DvzColorMap #{const DVZ_CMAP_BONE}
+pattern DVZ_CMAP_COOL :: DvzColorMap
+pattern DVZ_CMAP_COOL = DvzColorMap #{const DVZ_CMAP_COOL}
+pattern DVZ_CMAP_COPPER :: DvzColorMap
+pattern DVZ_CMAP_COPPER = DvzColorMap #{const DVZ_CMAP_COPPER}
+pattern DVZ_CMAP_GIST_HEAT :: DvzColorMap
+pattern DVZ_CMAP_GIST_HEAT = DvzColorMap #{const DVZ_CMAP_GIST_HEAT}
+pattern DVZ_CMAP_GRAY :: DvzColorMap
+pattern DVZ_CMAP_GRAY = DvzColorMap #{const DVZ_CMAP_GRAY}
+pattern DVZ_CMAP_HOT :: DvzColorMap
+pattern DVZ_CMAP_HOT = DvzColorMap #{const DVZ_CMAP_HOT}
+pattern DVZ_CMAP_PINK :: DvzColorMap
+pattern DVZ_CMAP_PINK = DvzColorMap #{const DVZ_CMAP_PINK}
+pattern DVZ_CMAP_SPRING :: DvzColorMap
+pattern DVZ_CMAP_SPRING = DvzColorMap #{const DVZ_CMAP_SPRING}
+pattern DVZ_CMAP_SUMMER :: DvzColorMap
+pattern DVZ_CMAP_SUMMER = DvzColorMap #{const DVZ_CMAP_SUMMER}
+pattern DVZ_CMAP_WINTER :: DvzColorMap
+pattern DVZ_CMAP_WINTER = DvzColorMap #{const DVZ_CMAP_WINTER}
+pattern DVZ_CMAP_WISTIA :: DvzColorMap
+pattern DVZ_CMAP_WISTIA = DvzColorMap #{const DVZ_CMAP_WISTIA}
+pattern DVZ_CMAP_BRBG :: DvzColorMap
+pattern DVZ_CMAP_BRBG = DvzColorMap #{const DVZ_CMAP_BRBG}
+pattern DVZ_CMAP_BWR :: DvzColorMap
+pattern DVZ_CMAP_BWR = DvzColorMap #{const DVZ_CMAP_BWR}
+pattern DVZ_CMAP_COOLWARM :: DvzColorMap
+pattern DVZ_CMAP_COOLWARM = DvzColorMap #{const DVZ_CMAP_COOLWARM}
+pattern DVZ_CMAP_PIYG :: DvzColorMap
+pattern DVZ_CMAP_PIYG = DvzColorMap #{const DVZ_CMAP_PIYG}
+pattern DVZ_CMAP_PRGN :: DvzColorMap
+pattern DVZ_CMAP_PRGN = DvzColorMap #{const DVZ_CMAP_PRGN}
+pattern DVZ_CMAP_PUOR :: DvzColorMap
+pattern DVZ_CMAP_PUOR = DvzColorMap #{const DVZ_CMAP_PUOR}
+pattern DVZ_CMAP_RDBU :: DvzColorMap
+pattern DVZ_CMAP_RDBU = DvzColorMap #{const DVZ_CMAP_RDBU}
+pattern DVZ_CMAP_RDGY :: DvzColorMap
+pattern DVZ_CMAP_RDGY = DvzColorMap #{const DVZ_CMAP_RDGY}
+pattern DVZ_CMAP_RDYLBU :: DvzColorMap
+pattern DVZ_CMAP_RDYLBU = DvzColorMap #{const DVZ_CMAP_RDYLBU}
+pattern DVZ_CMAP_RDYLGN :: DvzColorMap
+pattern DVZ_CMAP_RDYLGN = DvzColorMap #{const DVZ_CMAP_RDYLGN}
+pattern DVZ_CMAP_SEISMIC :: DvzColorMap
+pattern DVZ_CMAP_SEISMIC = DvzColorMap #{const DVZ_CMAP_SEISMIC}
+pattern DVZ_CMAP_SPECTRAL :: DvzColorMap
+pattern DVZ_CMAP_SPECTRAL = DvzColorMap #{const DVZ_CMAP_SPECTRAL}
+pattern DVZ_CMAP_TWILIGHT_SHIFTED :: DvzColorMap
+pattern DVZ_CMAP_TWILIGHT_SHIFTED = DvzColorMap #{const DVZ_CMAP_TWILIGHT_SHIFTED}
+pattern DVZ_CMAP_TWILIGHT :: DvzColorMap
+pattern DVZ_CMAP_TWILIGHT = DvzColorMap #{const DVZ_CMAP_TWILIGHT}
+pattern DVZ_CMAP_BRG :: DvzColorMap
+pattern DVZ_CMAP_BRG = DvzColorMap #{const DVZ_CMAP_BRG}
+pattern DVZ_CMAP_CMRMAP :: DvzColorMap
+pattern DVZ_CMAP_CMRMAP = DvzColorMap #{const DVZ_CMAP_CMRMAP}
+pattern DVZ_CMAP_CUBEHELIX :: DvzColorMap
+pattern DVZ_CMAP_CUBEHELIX = DvzColorMap #{const DVZ_CMAP_CUBEHELIX}
+pattern DVZ_CMAP_FLAG :: DvzColorMap
+pattern DVZ_CMAP_FLAG = DvzColorMap #{const DVZ_CMAP_FLAG}
+pattern DVZ_CMAP_GIST_EARTH :: DvzColorMap
+pattern DVZ_CMAP_GIST_EARTH = DvzColorMap #{const DVZ_CMAP_GIST_EARTH}
+pattern DVZ_CMAP_GIST_NCAR :: DvzColorMap
+pattern DVZ_CMAP_GIST_NCAR = DvzColorMap #{const DVZ_CMAP_GIST_NCAR}
+pattern DVZ_CMAP_GIST_RAINBOW :: DvzColorMap
+pattern DVZ_CMAP_GIST_RAINBOW = DvzColorMap #{const DVZ_CMAP_GIST_RAINBOW}
+pattern DVZ_CMAP_GIST_STERN :: DvzColorMap
+pattern DVZ_CMAP_GIST_STERN = DvzColorMap #{const DVZ_CMAP_GIST_STERN}
+pattern DVZ_CMAP_GNUPLOT2 :: DvzColorMap
+pattern DVZ_CMAP_GNUPLOT2 = DvzColorMap #{const DVZ_CMAP_GNUPLOT2}
+pattern DVZ_CMAP_GNUPLOT :: DvzColorMap
+pattern DVZ_CMAP_GNUPLOT = DvzColorMap #{const DVZ_CMAP_GNUPLOT}
+pattern DVZ_CMAP_JET :: DvzColorMap
+pattern DVZ_CMAP_JET = DvzColorMap #{const DVZ_CMAP_JET}
+pattern DVZ_CMAP_NIPY_SPECTRAL :: DvzColorMap
+pattern DVZ_CMAP_NIPY_SPECTRAL = DvzColorMap #{const DVZ_CMAP_NIPY_SPECTRAL}
+pattern DVZ_CMAP_OCEAN :: DvzColorMap
+pattern DVZ_CMAP_OCEAN = DvzColorMap #{const DVZ_CMAP_OCEAN}
+pattern DVZ_CMAP_PRISM :: DvzColorMap
+pattern DVZ_CMAP_PRISM = DvzColorMap #{const DVZ_CMAP_PRISM}
+pattern DVZ_CMAP_RAINBOW :: DvzColorMap
+pattern DVZ_CMAP_RAINBOW = DvzColorMap #{const DVZ_CMAP_RAINBOW}
+pattern DVZ_CMAP_TERRAIN :: DvzColorMap
+pattern DVZ_CMAP_TERRAIN = DvzColorMap #{const DVZ_CMAP_TERRAIN}
+pattern DVZ_CMAP_BKR :: DvzColorMap
+pattern DVZ_CMAP_BKR = DvzColorMap #{const DVZ_CMAP_BKR}
+pattern DVZ_CMAP_BKY :: DvzColorMap
+pattern DVZ_CMAP_BKY = DvzColorMap #{const DVZ_CMAP_BKY}
+pattern DVZ_CMAP_CET_D10 :: DvzColorMap
+pattern DVZ_CMAP_CET_D10 = DvzColorMap #{const DVZ_CMAP_CET_D10}
+pattern DVZ_CMAP_CET_D11 :: DvzColorMap
+pattern DVZ_CMAP_CET_D11 = DvzColorMap #{const DVZ_CMAP_CET_D11}
+pattern DVZ_CMAP_CET_D8 :: DvzColorMap
+pattern DVZ_CMAP_CET_D8 = DvzColorMap #{const DVZ_CMAP_CET_D8}
+pattern DVZ_CMAP_CET_D13 :: DvzColorMap
+pattern DVZ_CMAP_CET_D13 = DvzColorMap #{const DVZ_CMAP_CET_D13}
+pattern DVZ_CMAP_CET_D3 :: DvzColorMap
+pattern DVZ_CMAP_CET_D3 = DvzColorMap #{const DVZ_CMAP_CET_D3}
+pattern DVZ_CMAP_CET_D1A :: DvzColorMap
+pattern DVZ_CMAP_CET_D1A = DvzColorMap #{const DVZ_CMAP_CET_D1A}
+pattern DVZ_CMAP_BJY :: DvzColorMap
+pattern DVZ_CMAP_BJY = DvzColorMap #{const DVZ_CMAP_BJY}
+pattern DVZ_CMAP_GWV :: DvzColorMap
+pattern DVZ_CMAP_GWV = DvzColorMap #{const DVZ_CMAP_GWV}
+pattern DVZ_CMAP_BWY :: DvzColorMap
+pattern DVZ_CMAP_BWY = DvzColorMap #{const DVZ_CMAP_BWY}
+pattern DVZ_CMAP_CET_D12 :: DvzColorMap
+pattern DVZ_CMAP_CET_D12 = DvzColorMap #{const DVZ_CMAP_CET_D12}
+pattern DVZ_CMAP_CET_R3 :: DvzColorMap
+pattern DVZ_CMAP_CET_R3 = DvzColorMap #{const DVZ_CMAP_CET_R3}
+pattern DVZ_CMAP_CET_D9 :: DvzColorMap
+pattern DVZ_CMAP_CET_D9 = DvzColorMap #{const DVZ_CMAP_CET_D9}
+pattern DVZ_CMAP_CWR :: DvzColorMap
+pattern DVZ_CMAP_CWR = DvzColorMap #{const DVZ_CMAP_CWR}
+pattern DVZ_CMAP_CET_CBC1 :: DvzColorMap
+pattern DVZ_CMAP_CET_CBC1 = DvzColorMap #{const DVZ_CMAP_CET_CBC1}
+pattern DVZ_CMAP_CET_CBC2 :: DvzColorMap
+pattern DVZ_CMAP_CET_CBC2 = DvzColorMap #{const DVZ_CMAP_CET_CBC2}
+pattern DVZ_CMAP_CET_CBL1 :: DvzColorMap
+pattern DVZ_CMAP_CET_CBL1 = DvzColorMap #{const DVZ_CMAP_CET_CBL1}
+pattern DVZ_CMAP_CET_CBL2 :: DvzColorMap
+pattern DVZ_CMAP_CET_CBL2 = DvzColorMap #{const DVZ_CMAP_CET_CBL2}
+pattern DVZ_CMAP_CET_CBTC1 :: DvzColorMap
+pattern DVZ_CMAP_CET_CBTC1 = DvzColorMap #{const DVZ_CMAP_CET_CBTC1}
+pattern DVZ_CMAP_CET_CBTC2 :: DvzColorMap
+pattern DVZ_CMAP_CET_CBTC2 = DvzColorMap #{const DVZ_CMAP_CET_CBTC2}
+pattern DVZ_CMAP_CET_CBTL1 :: DvzColorMap
+pattern DVZ_CMAP_CET_CBTL1 = DvzColorMap #{const DVZ_CMAP_CET_CBTL1}
+pattern DVZ_CMAP_BGY :: DvzColorMap
+pattern DVZ_CMAP_BGY = DvzColorMap #{const DVZ_CMAP_BGY}
+pattern DVZ_CMAP_BGYW :: DvzColorMap
+pattern DVZ_CMAP_BGYW = DvzColorMap #{const DVZ_CMAP_BGYW}
+pattern DVZ_CMAP_BMW :: DvzColorMap
+pattern DVZ_CMAP_BMW = DvzColorMap #{const DVZ_CMAP_BMW}
+pattern DVZ_CMAP_CET_C1 :: DvzColorMap
+pattern DVZ_CMAP_CET_C1 = DvzColorMap #{const DVZ_CMAP_CET_C1}
+pattern DVZ_CMAP_CET_C1S :: DvzColorMap
+pattern DVZ_CMAP_CET_C1S = DvzColorMap #{const DVZ_CMAP_CET_C1S}
+pattern DVZ_CMAP_CET_C2 :: DvzColorMap
+pattern DVZ_CMAP_CET_C2 = DvzColorMap #{const DVZ_CMAP_CET_C2}
+pattern DVZ_CMAP_CET_C4 :: DvzColorMap
+pattern DVZ_CMAP_CET_C4 = DvzColorMap #{const DVZ_CMAP_CET_C4}
+pattern DVZ_CMAP_CET_C4S :: DvzColorMap
+pattern DVZ_CMAP_CET_C4S = DvzColorMap #{const DVZ_CMAP_CET_C4S}
+pattern DVZ_CMAP_CET_C5 :: DvzColorMap
+pattern DVZ_CMAP_CET_C5 = DvzColorMap #{const DVZ_CMAP_CET_C5}
+pattern DVZ_CMAP_CET_I1 :: DvzColorMap
+pattern DVZ_CMAP_CET_I1 = DvzColorMap #{const DVZ_CMAP_CET_I1}
+pattern DVZ_CMAP_CET_I3 :: DvzColorMap
+pattern DVZ_CMAP_CET_I3 = DvzColorMap #{const DVZ_CMAP_CET_I3}
+pattern DVZ_CMAP_CET_L10 :: DvzColorMap
+pattern DVZ_CMAP_CET_L10 = DvzColorMap #{const DVZ_CMAP_CET_L10}
+pattern DVZ_CMAP_CET_L11 :: DvzColorMap
+pattern DVZ_CMAP_CET_L11 = DvzColorMap #{const DVZ_CMAP_CET_L11}
+pattern DVZ_CMAP_CET_L12 :: DvzColorMap
+pattern DVZ_CMAP_CET_L12 = DvzColorMap #{const DVZ_CMAP_CET_L12}
+pattern DVZ_CMAP_CET_L16 :: DvzColorMap
+pattern DVZ_CMAP_CET_L16 = DvzColorMap #{const DVZ_CMAP_CET_L16}
+pattern DVZ_CMAP_CET_L17 :: DvzColorMap
+pattern DVZ_CMAP_CET_L17 = DvzColorMap #{const DVZ_CMAP_CET_L17}
+pattern DVZ_CMAP_CET_L18 :: DvzColorMap
+pattern DVZ_CMAP_CET_L18 = DvzColorMap #{const DVZ_CMAP_CET_L18}
+pattern DVZ_CMAP_CET_L19 :: DvzColorMap
+pattern DVZ_CMAP_CET_L19 = DvzColorMap #{const DVZ_CMAP_CET_L19}
+pattern DVZ_CMAP_CET_L4 :: DvzColorMap
+pattern DVZ_CMAP_CET_L4 = DvzColorMap #{const DVZ_CMAP_CET_L4}
+pattern DVZ_CMAP_CET_L7 :: DvzColorMap
+pattern DVZ_CMAP_CET_L7 = DvzColorMap #{const DVZ_CMAP_CET_L7}
+pattern DVZ_CMAP_CET_L8 :: DvzColorMap
+pattern DVZ_CMAP_CET_L8 = DvzColorMap #{const DVZ_CMAP_CET_L8}
+pattern DVZ_CMAP_CET_L9 :: DvzColorMap
+pattern DVZ_CMAP_CET_L9 = DvzColorMap #{const DVZ_CMAP_CET_L9}
+pattern DVZ_CMAP_CET_R1 :: DvzColorMap
+pattern DVZ_CMAP_CET_R1 = DvzColorMap #{const DVZ_CMAP_CET_R1}
+pattern DVZ_CMAP_CET_R2 :: DvzColorMap
+pattern DVZ_CMAP_CET_R2 = DvzColorMap #{const DVZ_CMAP_CET_R2}
+pattern DVZ_CMAP_COLORWHEEL :: DvzColorMap
+pattern DVZ_CMAP_COLORWHEEL = DvzColorMap #{const DVZ_CMAP_COLORWHEEL}
+pattern DVZ_CMAP_FIRE :: DvzColorMap
+pattern DVZ_CMAP_FIRE = DvzColorMap #{const DVZ_CMAP_FIRE}
+pattern DVZ_CMAP_ISOLUM :: DvzColorMap
+pattern DVZ_CMAP_ISOLUM = DvzColorMap #{const DVZ_CMAP_ISOLUM}
+pattern DVZ_CMAP_KB :: DvzColorMap
+pattern DVZ_CMAP_KB = DvzColorMap #{const DVZ_CMAP_KB}
+pattern DVZ_CMAP_KBC :: DvzColorMap
+pattern DVZ_CMAP_KBC = DvzColorMap #{const DVZ_CMAP_KBC}
+pattern DVZ_CMAP_KG :: DvzColorMap
+pattern DVZ_CMAP_KG = DvzColorMap #{const DVZ_CMAP_KG}
+pattern DVZ_CMAP_KGY :: DvzColorMap
+pattern DVZ_CMAP_KGY = DvzColorMap #{const DVZ_CMAP_KGY}
+pattern DVZ_CMAP_KR :: DvzColorMap
+pattern DVZ_CMAP_KR = DvzColorMap #{const DVZ_CMAP_KR}
+pattern DVZ_CMAP_BLACK_BODY :: DvzColorMap
+pattern DVZ_CMAP_BLACK_BODY = DvzColorMap #{const DVZ_CMAP_BLACK_BODY}
+pattern DVZ_CMAP_KINDLMANN :: DvzColorMap
+pattern DVZ_CMAP_KINDLMANN = DvzColorMap #{const DVZ_CMAP_KINDLMANN}
+pattern DVZ_CMAP_EXTENDED_KINDLMANN :: DvzColorMap
+pattern DVZ_CMAP_EXTENDED_KINDLMANN = DvzColorMap #{const DVZ_CMAP_EXTENDED_KINDLMANN}
+pattern DVZ_CPAL256_GLASBEY_COOL :: DvzColorMap
+pattern DVZ_CPAL256_GLASBEY_COOL = DvzColorMap #{const DVZ_CPAL256_GLASBEY_COOL}
+pattern DVZ_CPAL256_GLASBEY_DARK :: DvzColorMap
+pattern DVZ_CPAL256_GLASBEY_DARK = DvzColorMap #{const DVZ_CPAL256_GLASBEY_DARK}
+pattern DVZ_CPAL256_GLASBEY_HV :: DvzColorMap
+pattern DVZ_CPAL256_GLASBEY_HV = DvzColorMap #{const DVZ_CPAL256_GLASBEY_HV}
+pattern DVZ_CPAL256_GLASBEY_LIGHT :: DvzColorMap
+pattern DVZ_CPAL256_GLASBEY_LIGHT = DvzColorMap #{const DVZ_CPAL256_GLASBEY_LIGHT}
+pattern DVZ_CPAL256_GLASBEY_WARM :: DvzColorMap
+pattern DVZ_CPAL256_GLASBEY_WARM = DvzColorMap #{const DVZ_CPAL256_GLASBEY_WARM}
+pattern DVZ_CPAL032_DARK2 :: DvzColorMap
+pattern DVZ_CPAL032_DARK2 = DvzColorMap #{const DVZ_CPAL032_DARK2}
+pattern DVZ_CPAL032_PAIRED :: DvzColorMap
+pattern DVZ_CPAL032_PAIRED = DvzColorMap #{const DVZ_CPAL032_PAIRED}
+pattern DVZ_CPAL032_PASTEL1 :: DvzColorMap
+pattern DVZ_CPAL032_PASTEL1 = DvzColorMap #{const DVZ_CPAL032_PASTEL1}
+pattern DVZ_CPAL032_PASTEL2 :: DvzColorMap
+pattern DVZ_CPAL032_PASTEL2 = DvzColorMap #{const DVZ_CPAL032_PASTEL2}
+pattern DVZ_CPAL032_SET1 :: DvzColorMap
+pattern DVZ_CPAL032_SET1 = DvzColorMap #{const DVZ_CPAL032_SET1}
+pattern DVZ_CPAL032_SET2 :: DvzColorMap
+pattern DVZ_CPAL032_SET2 = DvzColorMap #{const DVZ_CPAL032_SET2}
+pattern DVZ_CPAL032_SET3 :: DvzColorMap
+pattern DVZ_CPAL032_SET3 = DvzColorMap #{const DVZ_CPAL032_SET3}
+pattern DVZ_CPAL032_TAB10 :: DvzColorMap
+pattern DVZ_CPAL032_TAB10 = DvzColorMap #{const DVZ_CPAL032_TAB10}
+pattern DVZ_CPAL032_TAB20 :: DvzColorMap
+pattern DVZ_CPAL032_TAB20 = DvzColorMap #{const DVZ_CPAL032_TAB20}
+pattern DVZ_CPAL032_TAB20B :: DvzColorMap
+pattern DVZ_CPAL032_TAB20B = DvzColorMap #{const DVZ_CPAL032_TAB20B}
+pattern DVZ_CPAL032_TAB20C :: DvzColorMap
+pattern DVZ_CPAL032_TAB20C = DvzColorMap #{const DVZ_CPAL032_TAB20C}
+pattern DVZ_CPAL032_CATEGORY10_10 :: DvzColorMap
+pattern DVZ_CPAL032_CATEGORY10_10 = DvzColorMap #{const DVZ_CPAL032_CATEGORY10_10}
+pattern DVZ_CPAL032_CATEGORY20_20 :: DvzColorMap
+pattern DVZ_CPAL032_CATEGORY20_20 = DvzColorMap #{const DVZ_CPAL032_CATEGORY20_20}
+pattern DVZ_CPAL032_CATEGORY20B_20 :: DvzColorMap
+pattern DVZ_CPAL032_CATEGORY20B_20 = DvzColorMap #{const DVZ_CPAL032_CATEGORY20B_20}
+pattern DVZ_CPAL032_CATEGORY20C_20 :: DvzColorMap
+pattern DVZ_CPAL032_CATEGORY20C_20 = DvzColorMap #{const DVZ_CPAL032_CATEGORY20C_20}
+pattern DVZ_CPAL032_COLORBLIND8:: DvzColorMap
+pattern DVZ_CPAL032_COLORBLIND8 = DvzColorMap #{const DVZ_CPAL032_COLORBLIND8}
+
+{-# COMPLETE
+    DVZ_CMAP_BINARY,
+    DVZ_CMAP_HSV,
+    DVZ_CMAP_CIVIDIS,
+    DVZ_CMAP_INFERNO,
+    DVZ_CMAP_MAGMA,
+    DVZ_CMAP_PLASMA,
+    DVZ_CMAP_VIRIDIS,
+    DVZ_CMAP_BLUES,
+    DVZ_CMAP_BUGN,
+    DVZ_CMAP_BUPU,
+    DVZ_CMAP_GNBU,
+    DVZ_CMAP_GREENS,
+    DVZ_CMAP_GREYS,
+    DVZ_CMAP_ORANGES,
+    DVZ_CMAP_ORRD,
+    DVZ_CMAP_PUBU,
+    DVZ_CMAP_PUBUGN,
+    DVZ_CMAP_PURPLES,
+    DVZ_CMAP_RDPU,
+    DVZ_CMAP_REDS,
+    DVZ_CMAP_YLGN,
+    DVZ_CMAP_YLGNBU,
+    DVZ_CMAP_YLORBR,
+    DVZ_CMAP_YLORRD,
+    DVZ_CMAP_AFMHOT,
+    DVZ_CMAP_AUTUMN,
+    DVZ_CMAP_BONE,
+    DVZ_CMAP_COOL,
+    DVZ_CMAP_COPPER,
+    DVZ_CMAP_GIST_HEAT,
+    DVZ_CMAP_GRAY,
+    DVZ_CMAP_HOT,
+    DVZ_CMAP_PINK,
+    DVZ_CMAP_SPRING,
+    DVZ_CMAP_SUMMER,
+    DVZ_CMAP_WINTER,
+    DVZ_CMAP_WISTIA,
+    DVZ_CMAP_BRBG,
+    DVZ_CMAP_BWR,
+    DVZ_CMAP_COOLWARM,
+    DVZ_CMAP_PIYG,
+    DVZ_CMAP_PRGN,
+    DVZ_CMAP_PUOR,
+    DVZ_CMAP_RDBU,
+    DVZ_CMAP_RDGY,
+    DVZ_CMAP_RDYLBU,
+    DVZ_CMAP_RDYLGN,
+    DVZ_CMAP_SEISMIC,
+    DVZ_CMAP_SPECTRAL,
+    DVZ_CMAP_TWILIGHT_SHIFTED,
+    DVZ_CMAP_TWILIGHT,
+    DVZ_CMAP_BRG,
+    DVZ_CMAP_CMRMAP,
+    DVZ_CMAP_CUBEHELIX,
+    DVZ_CMAP_FLAG,
+    DVZ_CMAP_GIST_EARTH,
+    DVZ_CMAP_GIST_NCAR,
+    DVZ_CMAP_GIST_RAINBOW,
+    DVZ_CMAP_GIST_STERN,
+    DVZ_CMAP_GNUPLOT2,
+    DVZ_CMAP_GNUPLOT,
+    DVZ_CMAP_JET,
+    DVZ_CMAP_NIPY_SPECTRAL,
+    DVZ_CMAP_OCEAN,
+    DVZ_CMAP_PRISM,
+    DVZ_CMAP_RAINBOW,
+    DVZ_CMAP_TERRAIN,
+    DVZ_CMAP_BKR,
+    DVZ_CMAP_BKY,
+    DVZ_CMAP_CET_D10,
+    DVZ_CMAP_CET_D11,
+    DVZ_CMAP_CET_D8,
+    DVZ_CMAP_CET_D13,
+    DVZ_CMAP_CET_D3,
+    DVZ_CMAP_CET_D1A,
+    DVZ_CMAP_BJY,
+    DVZ_CMAP_GWV,
+    DVZ_CMAP_BWY,
+    DVZ_CMAP_CET_D12,
+    DVZ_CMAP_CET_R3,
+    DVZ_CMAP_CET_D9,
+    DVZ_CMAP_CWR,
+    DVZ_CMAP_CET_CBC1,
+    DVZ_CMAP_CET_CBC2,
+    DVZ_CMAP_CET_CBL1,
+    DVZ_CMAP_CET_CBL2,
+    DVZ_CMAP_CET_CBTC1,
+    DVZ_CMAP_CET_CBTC2,
+    DVZ_CMAP_CET_CBTL1,
+    DVZ_CMAP_BGY,
+    DVZ_CMAP_BGYW,
+    DVZ_CMAP_BMW,
+    DVZ_CMAP_CET_C1,
+    DVZ_CMAP_CET_C1S,
+    DVZ_CMAP_CET_C2,
+    DVZ_CMAP_CET_C4,
+    DVZ_CMAP_CET_C4S,
+    DVZ_CMAP_CET_C5,
+    DVZ_CMAP_CET_I1,
+    DVZ_CMAP_CET_I3,
+    DVZ_CMAP_CET_L10,
+    DVZ_CMAP_CET_L11,
+    DVZ_CMAP_CET_L12,
+    DVZ_CMAP_CET_L16,
+    DVZ_CMAP_CET_L17,
+    DVZ_CMAP_CET_L18,
+    DVZ_CMAP_CET_L19,
+    DVZ_CMAP_CET_L4,
+    DVZ_CMAP_CET_L7,
+    DVZ_CMAP_CET_L8,
+    DVZ_CMAP_CET_L9,
+    DVZ_CMAP_CET_R1,
+    DVZ_CMAP_CET_R2,
+    DVZ_CMAP_COLORWHEEL,
+    DVZ_CMAP_FIRE,
+    DVZ_CMAP_ISOLUM,
+    DVZ_CMAP_KB,
+    DVZ_CMAP_KBC,
+    DVZ_CMAP_KG,
+    DVZ_CMAP_KGY,
+    DVZ_CMAP_KR,
+    DVZ_CMAP_BLACK_BODY,
+    DVZ_CMAP_KINDLMANN,
+    DVZ_CMAP_EXTENDED_KINDLMANN,
+    DVZ_CPAL256_GLASBEY_COOL,
+    DVZ_CPAL256_GLASBEY_DARK,
+    DVZ_CPAL256_GLASBEY_HV,
+    DVZ_CPAL256_GLASBEY_LIGHT,
+    DVZ_CPAL256_GLASBEY_WARM,
+    DVZ_CPAL032_DARK2,
+    DVZ_CPAL032_PAIRED,
+    DVZ_CPAL032_PASTEL1,
+    DVZ_CPAL032_PASTEL2,
+    DVZ_CPAL032_SET1,
+    DVZ_CPAL032_SET2,
+    DVZ_CPAL032_SET3,
+    DVZ_CPAL032_TAB10,
+    DVZ_CPAL032_TAB20,
+    DVZ_CPAL032_TAB20B,
+    DVZ_CPAL032_TAB20C,
+    DVZ_CPAL032_CATEGORY10_10,
+    DVZ_CPAL032_CATEGORY20_20,
+    DVZ_CPAL032_CATEGORY20B_20,
+    DVZ_CPAL032_CATEGORY20C_20,
+    DVZ_CPAL032_COLORBLIND8
+    #-}
+
+-- foreign import capi safe "datoviz/datoviz.h" dvz_colormap_scale
+--     :: DvzColorMap -> Double -> Double -> Double -> CVec4 -> IO ()
+

--- a/src/Graphics/Datoviz/Panel.hsc
+++ b/src/Graphics/Datoviz/Panel.hsc
@@ -1,0 +1,7 @@
+module Graphics.Datoviz.Panel where
+
+import Foreign.Ptr
+
+data C_DvzPanel
+
+newtype DvzPanel = DvzPanel { getDvzPanel :: Ptr C_DvzPanel }

--- a/src/Graphics/Datoviz/Scene.hsc
+++ b/src/Graphics/Datoviz/Scene.hsc
@@ -1,0 +1,96 @@
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE PatternSynonyms #-}
+
+module Graphics.Datoviz.Scene where
+
+import Data.Word
+import Foreign.C.Types
+import Foreign.Ptr
+import Graphics.Datoviz.Canvas
+import Graphics.Datoviz.Colormaps
+import Graphics.Datoviz.Panel
+import Graphics.Datoviz.Vklite
+import Graphics.Datoviz.Visuals
+
+#include <datoviz/datoviz.h>
+
+data C_DvzScene
+
+newtype DvzScene = DvzScene { getDvzScene :: Ptr C_DvzScene }
+
+newtype DvzControllerType = DvzControllerType { getDvzControllerType :: CInt }
+
+pattern DVZ_CONTROLLER_NONE :: DvzControllerType
+pattern DVZ_CONTROLLER_NONE = DvzControllerType #{const DVZ_CONTROLLER_NONE}
+
+pattern DVZ_CONTROLLER_PANZOOM :: DvzControllerType
+pattern DVZ_CONTROLLER_PANZOOM = DvzControllerType #{const DVZ_CONTROLLER_PANZOOM}
+
+pattern DVZ_CONTROLLER_AXES_2D :: DvzControllerType
+pattern DVZ_CONTROLLER_AXES_2D = DvzControllerType #{const DVZ_CONTROLLER_AXES_2D}
+
+pattern DVZ_CONTROLLER_ARCBALL :: DvzControllerType
+pattern DVZ_CONTROLLER_ARCBALL = DvzControllerType #{const DVZ_CONTROLLER_ARCBALL}
+
+pattern DVZ_CONTROLLER_CAMERA :: DvzControllerType
+pattern DVZ_CONTROLLER_CAMERA = DvzControllerType #{const DVZ_CONTROLLER_CAMERA}
+
+pattern DVZ_CONTROLLER_AXES_3D :: DvzControllerType
+pattern DVZ_CONTROLLER_AXES_3D = DvzControllerType #{const DVZ_CONTROLLER_AXES_3D}
+{-# COMPLETE DVZ_CONTROLLER_NONE, DVZ_CONTROLLER_PANZOOM, DVZ_CONTROLLER_AXES_2D
+  , DVZ_CONTROLLER_ARCBALL, DVZ_CONTROLLER_CAMERA, DVZ_CONTROLLER_AXES_3D #-}
+
+newtype DvzVisualFlags = DvzVisualFlags { getDvzVisualFlags :: CInt }
+
+newtype DvzSceneUpdateType = DvzSceneUpdateType { getDvzSceneUpdateType :: CInt }
+
+pattern DVZ_SCENE_UPDATE_NONE :: DvzSceneUpdateType
+pattern DVZ_SCENE_UPDATE_NONE = DvzSceneUpdateType #{const DVZ_SCENE_UPDATE_NONE}
+
+pattern DVZ_SCENE_UPDATE_VISUAL_ADDED :: DvzSceneUpdateType
+pattern DVZ_SCENE_UPDATE_VISUAL_ADDED = DvzSceneUpdateType #{const DVZ_SCENE_UPDATE_VISUAL_ADDED }
+
+pattern DVZ_SCENE_UPDATE_VISUAL_CHANGED :: DvzSceneUpdateType
+pattern DVZ_SCENE_UPDATE_VISUAL_CHANGED = DvzSceneUpdateType #{const DVZ_SCENE_UPDATE_VISUAL_CHANGED }
+
+pattern DVZ_SCENE_UPDATE_PROP_CHANGED :: DvzSceneUpdateType
+pattern DVZ_SCENE_UPDATE_PROP_CHANGED = DvzSceneUpdateType #{const DVZ_SCENE_UPDATE_PROP_CHANGED }
+
+pattern DVZ_SCENE_UPDATE_VISIBILITY_CHANGED :: DvzSceneUpdateType
+pattern DVZ_SCENE_UPDATE_VISIBILITY_CHANGED = DvzSceneUpdateType #{const DVZ_SCENE_UPDATE_VISIBILITY_CHANGED }
+
+pattern DVZ_SCENE_UPDATE_ITEM_COUNT_CHANGED :: DvzSceneUpdateType
+pattern DVZ_SCENE_UPDATE_ITEM_COUNT_CHANGED = DvzSceneUpdateType #{const DVZ_SCENE_UPDATE_ITEM_COUNT_CHANGED }
+
+pattern DVZ_SCENE_UPDATE_PANEL_CHANGED :: DvzSceneUpdateType
+pattern DVZ_SCENE_UPDATE_PANEL_CHANGED = DvzSceneUpdateType #{const DVZ_SCENE_UPDATE_PANEL_CHANGED }
+
+pattern DVZ_SCENE_UPDATE_INTERACT_CHANGED :: DvzSceneUpdateType
+pattern DVZ_SCENE_UPDATE_INTERACT_CHANGED = DvzSceneUpdateType #{const DVZ_SCENE_UPDATE_INTERACT_CHANGED }
+
+pattern DVZ_SCENE_UPDATE_COORDS_CHANGED :: DvzSceneUpdateType
+pattern DVZ_SCENE_UPDATE_COORDS_CHANGED = DvzSceneUpdateType #{const DVZ_SCENE_UPDATE_COORDS_CHANGED }
+
+{-# COMPLETE
+      DVZ_SCENE_UPDATE_NONE
+    , DVZ_SCENE_UPDATE_VISUAL_ADDED
+    , DVZ_SCENE_UPDATE_VISUAL_CHANGED
+    , DVZ_SCENE_UPDATE_PROP_CHANGED
+    , DVZ_SCENE_UPDATE_VISIBILITY_CHANGED
+    , DVZ_SCENE_UPDATE_ITEM_COUNT_CHANGED
+    , DVZ_SCENE_UPDATE_PANEL_CHANGED
+    , DVZ_SCENE_UPDATE_INTERACT_CHANGED
+    , DVZ_SCENE_UPDATE_COORDS_CHANGED #-}
+
+foreign import ccall dvz_scene :: DvzCanvas -> Word32 -> Word32 -> IO DvzScene
+foreign import capi safe "datoviz/datoviz.h" dvz_scene_destroy :: DvzScene -> IO ()
+
+foreign import ccall dvz_custom_graphics :: DvzVisual -> DvzGraphics -> IO ()
+foreign import ccall dvz_custom_visual :: DvzPanel -> DvzVisual -> IO ()
+
+foreign import ccall dvz_scene_panel :: DvzScene -> Word32 -> Word32 -> DvzControllerType -> CInt -> IO DvzPanel
+foreign import ccall dvz_blank_visual :: DvzScene -> CInt -> IO DvzVisual
+foreign import ccall dvz_blank_graphics :: DvzScene -> CInt -> IO DvzGraphics
+
+foreign import capi safe "datoviz/datoviz.h" dvz_scene_visual :: DvzPanel -> DvzVisualType -> CInt -> IO DvzVisual
+

--- a/src/Graphics/Datoviz/Scene.hsc
+++ b/src/Graphics/Datoviz/Scene.hsc
@@ -7,7 +7,6 @@ import Data.Word
 import Foreign.C.Types
 import Foreign.Ptr
 import Graphics.Datoviz.Canvas
-import Graphics.Datoviz.Colormaps
 import Graphics.Datoviz.Panel
 import Graphics.Datoviz.Vklite
 import Graphics.Datoviz.Visuals

--- a/src/Graphics/Datoviz/Types.hs
+++ b/src/Graphics/Datoviz/Types.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -11,7 +11,7 @@ import Data.Vector.Storable qualified as VS
 import Foreign
 import GHC.TypeNats
 
--- | Fixed-Sized Vector with type `a` and length of `b`.
+-- | Fixed-Sized Vector with type `a` and length `b`.
 newtype FsVec a (b :: Nat) = FsVec (VS.Vector a)
 
 -- 8-bit integers

--- a/src/Graphics/Datoviz/Types.hs
+++ b/src/Graphics/Datoviz/Types.hs
@@ -4,88 +4,65 @@
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 module Graphics.Datoviz.Types where
 
-import Data.Coerce (coerce)
-import Data.Data
-import Data.Vector.Storable qualified as VS
-import Foreign
-import GHC.TypeNats
-
--- | Fixed-Sized Vector with type `a` and length `b`.
-newtype FsVec a (b :: Nat) = FsVec (VS.Vector a)
-    deriving (Eq, Show)
+import Data.Int
+import Data.Word
+import Foreign.Storable
+import Linear.V2 qualified as L
+import Linear.V3 qualified as L
+import Linear.V4 qualified as L
 
 -- 8-bit integers
-newtype CVec2 = CVec2 (FsVec Word8 2)
+newtype CVec2 = CVec2 (L.V2 Word8)
     deriving (Eq, Show, Storable)
-newtype CVec3 = CVec3 (FsVec Word8 3)
+newtype CVec3 = CVec3 (L.V3 Word8)
     deriving (Eq, Show, Storable)
-newtype CVec4 = CVec4 (FsVec Word8 4)
+newtype CVec4 = CVec4 (L.V4 Word8)
     deriving (Eq, Show, Storable)
 
 -- 16-bit integers
-newtype SVec2 = SVec2 (FsVec Int16 2)
+newtype SVec2 = SVec2 (L.V2 Int16)
     deriving (Eq, Show, Storable)
-newtype SVec3 = SVec3 (FsVec Int16 3)
+newtype SVec3 = SVec3 (L.V3 Int16)
     deriving (Eq, Show, Storable)
-newtype SVec4 = SVec4 (FsVec Int16 4)
+newtype SVec4 = SVec4 (L.V4 Int16)
     deriving (Eq, Show, Storable)
 
-newtype UsVec2 = UsVec2 (FsVec Word16 2)
+newtype UsVec2 = UsVec2 (L.V2 Word16)
     deriving (Eq, Show, Storable)
-newtype UsVec3 = UsVec3 (FsVec Word16 3)
+newtype UsVec3 = UsVec3 (L.V3 Word16)
     deriving (Eq, Show, Storable)
-newtype UsVec4 = UsVec4 (FsVec Word16 4)
+newtype UsVec4 = UsVec4 (L.V4 Word16)
     deriving (Eq, Show, Storable)
 
 -- 32-bit integers
-newtype IVec2 = IVec2 (FsVec Int32 2)
+newtype IVec2 = IVec2 (L.V2 Int32)
     deriving (Eq, Show, Storable)
-newtype IVec3 = IVec3 (FsVec Int32 3)
+newtype IVec3 = IVec3 (L.V3 Int32)
     deriving (Eq, Show, Storable)
-newtype IVec4 = IVec4 (FsVec Int32 4)
+newtype IVec4 = IVec4 (L.V4 Int32)
     deriving (Eq, Show, Storable)
 
-newtype UVec2 = UVec2 (FsVec Word32 2)
+newtype UVec2 = UVec2 (L.V2 Word32)
     deriving (Eq, Show, Storable)
-newtype UVec3 = UVec3 (FsVec Word32 3)
+newtype UVec3 = UVec3 (L.V3 Word32)
     deriving (Eq, Show, Storable)
-newtype UVec4 = UVec4 (FsVec Word32 4)
+newtype UVec4 = UVec4 (L.V4 Word32)
     deriving (Eq, Show, Storable)
 
 -- single precision floating point numbers
-newtype FVec2 = FVec2 (FsVec Float 2)
+newtype FVec2 = FVec2 (L.V2 Float)
     deriving (Eq, Show, Storable)
-newtype FVec3 = FVec3 (FsVec Float 3)
+newtype FVec3 = FVec3 (L.V3 Float)
     deriving (Eq, Show, Storable)
-newtype FVec4 = FVec4 (FsVec Float 4)
+newtype FVec4 = FVec4 (L.V4 Float)
     deriving (Eq, Show, Storable)
 
 -- double precision floating point numbers
-newtype DVec2 = DVec2 (FsVec Double 2)
+newtype DVec2 = DVec2 (L.V2 Double)
     deriving (Eq, Show, Storable)
-newtype DVec3 = DVec3 (FsVec Double 3)
+newtype DVec3 = DVec3 (L.V3 Double)
     deriving (Eq, Show, Storable)
-newtype DVec4 = DVec4 (FsVec Double 4)
+newtype DVec4 = DVec4 (L.V4 Double)
     deriving (Eq, Show, Storable)
-
-instance (Storable a, KnownNat b) => Storable (FsVec a b) where
-    sizeOf _ = fromIntegral (natVal (Proxy @b)) * sizeOf (undefined :: a)
-    alignment _ = alignment (undefined :: a)
-    peek srcPtr = do
-        -- this is a bit sketchy but walk through this with me.
-        --
-        -- len is the value-level of b.
-        let len = fromIntegral (natVal (Proxy @b))
-        -- malloc a foreign ptr with enough bytes to fit a (FsVec a b)
-        destFp <- mallocForeignPtrBytes (sizeOf (undefined :: (FsVec a b)))
-        withForeignPtr destFp $ \ destPtr -> do
-            -- copy from our srcPtr to the destPtr `len` elements with sizeOf (undefined :: a)
-            copyArray srcPtr destPtr len
-        -- create a storable vector from the malloc'ed ForeignPtr above.
-        pure $ FsVec $ VS.unsafeFromForeignPtr0 (castForeignPtr destFp) len
-    poke ptr fsv = do
-        withForeignPtr (fst $ VS.unsafeToForeignPtr0 (coerce fsv)) $ \vptr -> do
-            moveArray ptr vptr (fromIntegral (natVal (Proxy @b)))

--- a/src/Graphics/Datoviz/Types.hs
+++ b/src/Graphics/Datoviz/Types.hs
@@ -1,11 +1,54 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 module Graphics.Datoviz.Types where
 
-import Foreign (Storable)
+import Data.Data
+import Data.Vector.Storable qualified as VS
+import Foreign
 import GHC.TypeNats
 
-newtype CVec a (b :: Nat) = CVec (V.Vector a)
+-- | Fixed-Sized Vector with type `a` and length of `b`.
+newtype FsVec a (b :: Nat) = FsVec (VS.Vector a)
 
-instance (Storable a, KnownNat b) => Storable (CVec a b) where
+-- 8-bit integers
+type CVec2 = FsVec Word8 2
+type CVec3 = FsVec Word8 3
+type CVec4 = FsVec Word8 4
+
+-- 16-bit integers
+type SVec2 = FsVec Int16 2
+type SVec3 = FsVec Int16 3
+type SVec4 = FsVec Int16 4
+
+type UsVec2 = FsVec Word16 2
+type UsVec3 = FsVec Word16 3
+type UsVec4 = FsVec Word16 4
+
+-- 32-bit integers
+type IVec2 = FsVec Int32 2
+type IVec3 = FsVec Int32 3
+type IVec4 = FsVec Int32 4
+
+type UVec2 = FsVec Word32 2
+type UVec3 = FsVec Word32 3
+type UVec4 = FsVec Word32 4
+
+-- single precision floating point numbers
+type FVec2 = FsVec Float 2
+type FVec3 = FsVec Float 3
+type FVec4 = FsVec Float 4
+
+-- double precision floating point numbers
+type DVec2 = FsVec Double 2
+type DVec3 = FsVec Double 3
+type DVec4 = FsVec Double 4
+
+instance (Storable a, KnownNat b) => Storable (FsVec a b) where
+    sizeOf _ = fromIntegral (natVal (Proxy @b)) * sizeOf (undefined :: a)
+    alignment _ = alignment (undefined :: a)
+    peek p = undefined
+    poke p cv = undefined

--- a/src/Graphics/Datoviz/Types.hs
+++ b/src/Graphics/Datoviz/Types.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 module Graphics.Datoviz.Types where
 
+import Data.Coerce (coerce)
 import Data.Data
 import Data.Vector.Storable qualified as VS
 import Foreign
@@ -13,42 +15,77 @@ import GHC.TypeNats
 
 -- | Fixed-Sized Vector with type `a` and length `b`.
 newtype FsVec a (b :: Nat) = FsVec (VS.Vector a)
+    deriving (Eq, Show)
 
 -- 8-bit integers
-type CVec2 = FsVec Word8 2
-type CVec3 = FsVec Word8 3
-type CVec4 = FsVec Word8 4
+newtype CVec2 = CVec2 (FsVec Word8 2)
+    deriving (Eq, Show, Storable)
+newtype CVec3 = CVec3 (FsVec Word8 3)
+    deriving (Eq, Show, Storable)
+newtype CVec4 = CVec4 (FsVec Word8 4)
+    deriving (Eq, Show, Storable)
 
 -- 16-bit integers
-type SVec2 = FsVec Int16 2
-type SVec3 = FsVec Int16 3
-type SVec4 = FsVec Int16 4
+newtype SVec2 = SVec2 (FsVec Int16 2)
+    deriving (Eq, Show, Storable)
+newtype SVec3 = SVec3 (FsVec Int16 3)
+    deriving (Eq, Show, Storable)
+newtype SVec4 = SVec4 (FsVec Int16 4)
+    deriving (Eq, Show, Storable)
 
-type UsVec2 = FsVec Word16 2
-type UsVec3 = FsVec Word16 3
-type UsVec4 = FsVec Word16 4
+newtype UsVec2 = UsVec2 (FsVec Word16 2)
+    deriving (Eq, Show, Storable)
+newtype UsVec3 = UsVec3 (FsVec Word16 3)
+    deriving (Eq, Show, Storable)
+newtype UsVec4 = UsVec4 (FsVec Word16 4)
+    deriving (Eq, Show, Storable)
 
 -- 32-bit integers
-type IVec2 = FsVec Int32 2
-type IVec3 = FsVec Int32 3
-type IVec4 = FsVec Int32 4
+newtype IVec2 = IVec2 (FsVec Int32 2)
+    deriving (Eq, Show, Storable)
+newtype IVec3 = IVec3 (FsVec Int32 3)
+    deriving (Eq, Show, Storable)
+newtype IVec4 = IVec4 (FsVec Int32 4)
+    deriving (Eq, Show, Storable)
 
-type UVec2 = FsVec Word32 2
-type UVec3 = FsVec Word32 3
-type UVec4 = FsVec Word32 4
+newtype UVec2 = UVec2 (FsVec Word32 2)
+    deriving (Eq, Show, Storable)
+newtype UVec3 = UVec3 (FsVec Word32 3)
+    deriving (Eq, Show, Storable)
+newtype UVec4 = UVec4 (FsVec Word32 4)
+    deriving (Eq, Show, Storable)
 
 -- single precision floating point numbers
-type FVec2 = FsVec Float 2
-type FVec3 = FsVec Float 3
-type FVec4 = FsVec Float 4
+newtype FVec2 = FVec2 (FsVec Float 2)
+    deriving (Eq, Show, Storable)
+newtype FVec3 = FVec3 (FsVec Float 3)
+    deriving (Eq, Show, Storable)
+newtype FVec4 = FVec4 (FsVec Float 4)
+    deriving (Eq, Show, Storable)
 
 -- double precision floating point numbers
-type DVec2 = FsVec Double 2
-type DVec3 = FsVec Double 3
-type DVec4 = FsVec Double 4
+newtype DVec2 = DVec2 (FsVec Double 2)
+    deriving (Eq, Show, Storable)
+newtype DVec3 = DVec3 (FsVec Double 3)
+    deriving (Eq, Show, Storable)
+newtype DVec4 = DVec4 (FsVec Double 4)
+    deriving (Eq, Show, Storable)
 
 instance (Storable a, KnownNat b) => Storable (FsVec a b) where
     sizeOf _ = fromIntegral (natVal (Proxy @b)) * sizeOf (undefined :: a)
     alignment _ = alignment (undefined :: a)
-    peek p = undefined
-    poke p cv = undefined
+    peek srcPtr = do
+        -- this is a bit sketchy but walk through this with me.
+        --
+        -- len is the value-level of b.
+        let len = fromIntegral (natVal (Proxy @b))
+        -- malloc a foreign ptr with enough bytes to fit a (FsVec a b)
+        destFp <- mallocForeignPtrBytes (sizeOf (undefined :: (FsVec a b)))
+        withForeignPtr destFp $ \ destPtr -> do
+            -- copy from our srcPtr to the destPtr `len` elements with sizeOf (undefined :: a)
+            copyArray srcPtr destPtr len
+        -- create a storable vector from the malloc'ed ForeignPtr above.
+        pure $ FsVec $ VS.unsafeFromForeignPtr0 (castForeignPtr destFp) len
+    poke ptr fsv = do
+        withForeignPtr (fst $ VS.unsafeToForeignPtr0 (coerce fsv)) $ \vptr -> do
+            moveArray ptr vptr (fromIntegral (natVal (Proxy @b)))

--- a/src/Graphics/Datoviz/Types.hs
+++ b/src/Graphics/Datoviz/Types.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DataKinds #-}
+module Graphics.Datoviz.Types where
+
+import Foreign (Storable)
+import GHC.TypeNats
+
+newtype CVec a (b :: Nat) = CVec (V.Vector a)
+
+instance (Storable a, KnownNat b) => Storable (CVec a b) where

--- a/src/Graphics/Datoviz/Visuals.hsc
+++ b/src/Graphics/Datoviz/Visuals.hsc
@@ -287,5 +287,5 @@ pattern DVZ_PROP_TRANSFORM = DvzPropType #{const DVZ_PROP_TRANSFORM}
 
 foreign import ccall dvz_visual_data_source :: DvzVisual -> DvzSourceType -> Word32 -> Word32 -> Word32 -> Word32 -> Ptr () -> IO ()
 
-foreign import capi safe "datoviz/datoviz.h"
-    dvz_visual_data :: DvzVisual -> DvzPropType -> Word32 -> Word32 -> Ptr () -> IO ()
+foreign import capi safe "datoviz/datoviz.h dvz_visual_data"
+    c_dvz_visual_data :: DvzVisual -> DvzPropType -> Word32 -> Word32 -> Ptr () -> IO ()

--- a/src/Graphics/Datoviz/Visuals.hsc
+++ b/src/Graphics/Datoviz/Visuals.hsc
@@ -1,0 +1,291 @@
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE PatternSynonyms #-}
+
+module Graphics.Datoviz.Visuals where
+
+import Data.Word
+import Foreign.C.Types
+import Foreign.Ptr
+
+#include <datoviz/datoviz.h>
+
+data C_DvzVisual
+
+newtype DvzVisual = DvzVisual { getDvzVisual :: Ptr C_DvzVisual }
+
+newtype DvzSourceType = DvzSourceType { getDvzSourceType :: CInt }
+
+pattern DVZ_SOURCE_TYPE_NONE :: DvzSourceType
+pattern DVZ_SOURCE_TYPE_NONE = DvzSourceType #{const DVZ_SOURCE_TYPE_NONE}
+
+pattern DVZ_SOURCE_TYPE_MVP :: DvzSourceType
+pattern DVZ_SOURCE_TYPE_MVP = DvzSourceType #{const DVZ_SOURCE_TYPE_MVP}
+
+pattern DVZ_SOURCE_TYPE_VIEWPORT :: DvzSourceType
+pattern DVZ_SOURCE_TYPE_VIEWPORT = DvzSourceType #{const DVZ_SOURCE_TYPE_VIEWPORT}
+
+pattern DVZ_SOURCE_TYPE_PARAM :: DvzSourceType
+pattern DVZ_SOURCE_TYPE_PARAM = DvzSourceType #{const DVZ_SOURCE_TYPE_PARAM}
+
+pattern DVZ_SOURCE_TYPE_VERTEX :: DvzSourceType
+pattern DVZ_SOURCE_TYPE_VERTEX = DvzSourceType #{const DVZ_SOURCE_TYPE_VERTEX}
+
+pattern DVZ_SOURCE_TYPE_INDEX :: DvzSourceType
+pattern DVZ_SOURCE_TYPE_INDEX = DvzSourceType #{const DVZ_SOURCE_TYPE_INDEX}
+
+pattern DVZ_SOURCE_TYPE_IMAGE :: DvzSourceType
+pattern DVZ_SOURCE_TYPE_IMAGE = DvzSourceType #{const DVZ_SOURCE_TYPE_IMAGE}
+
+pattern DVZ_SOURCE_TYPE_VOLUME :: DvzSourceType
+pattern DVZ_SOURCE_TYPE_VOLUME = DvzSourceType #{const DVZ_SOURCE_TYPE_VOLUME}
+
+pattern DVZ_SOURCE_TYPE_TRANSFER :: DvzSourceType
+pattern DVZ_SOURCE_TYPE_TRANSFER = DvzSourceType #{const DVZ_SOURCE_TYPE_TRANSFER}
+
+pattern DVZ_SOURCE_TYPE_COLOR_TEXTURE :: DvzSourceType
+pattern DVZ_SOURCE_TYPE_COLOR_TEXTURE = DvzSourceType #{const DVZ_SOURCE_TYPE_COLOR_TEXTURE}
+
+pattern DVZ_SOURCE_TYPE_FONT_ATLAS :: DvzSourceType
+pattern DVZ_SOURCE_TYPE_FONT_ATLAS = DvzSourceType #{const DVZ_SOURCE_TYPE_FONT_ATLAS}
+
+pattern DVZ_SOURCE_TYPE_OTHER :: DvzSourceType
+pattern DVZ_SOURCE_TYPE_OTHER = DvzSourceType #{const DVZ_SOURCE_TYPE_OTHER}
+
+pattern DVZ_SOURCE_TYPE_COUNT :: DvzSourceType
+pattern DVZ_SOURCE_TYPE_COUNT = DvzSourceType #{const DVZ_SOURCE_TYPE_COUNT}
+
+{-# COMPLETE DVZ_SOURCE_TYPE_NONE,
+              DVZ_SOURCE_TYPE_MVP,
+              DVZ_SOURCE_TYPE_VIEWPORT,
+              DVZ_SOURCE_TYPE_PARAM,
+              DVZ_SOURCE_TYPE_VERTEX,
+              DVZ_SOURCE_TYPE_INDEX,
+              DVZ_SOURCE_TYPE_IMAGE,
+              DVZ_SOURCE_TYPE_VOLUME,
+              DVZ_SOURCE_TYPE_TRANSFER,
+              DVZ_SOURCE_TYPE_COLOR_TEXTURE,
+              DVZ_SOURCE_TYPE_FONT_ATLAS,
+              DVZ_SOURCE_TYPE_OTHER,
+              DVZ_SOURCE_TYPE_COUNT #-}
+
+newtype DvzVisualType = DvzVisualType { getDvzVisualType :: CInt }
+
+pattern DVZ_VISUAL_NONE :: DvzVisualType
+pattern DVZ_VISUAL_NONE = DvzVisualType #{const DVZ_VISUAL_NONE}
+pattern DVZ_VISUAL_POINT :: DvzVisualType
+pattern DVZ_VISUAL_POINT = DvzVisualType #{const DVZ_VISUAL_POINT}
+pattern DVZ_VISUAL_LINE :: DvzVisualType
+pattern DVZ_VISUAL_LINE = DvzVisualType #{const DVZ_VISUAL_LINE}
+pattern DVZ_VISUAL_LINE_STRIP :: DvzVisualType
+pattern DVZ_VISUAL_LINE_STRIP = DvzVisualType #{const DVZ_VISUAL_LINE_STRIP}
+pattern DVZ_VISUAL_TRIANGLE :: DvzVisualType
+pattern DVZ_VISUAL_TRIANGLE = DvzVisualType #{const DVZ_VISUAL_TRIANGLE}
+pattern DVZ_VISUAL_TRIANGLE_STRIP :: DvzVisualType
+pattern DVZ_VISUAL_TRIANGLE_STRIP = DvzVisualType #{const DVZ_VISUAL_TRIANGLE_STRIP}
+pattern DVZ_VISUAL_TRIANGLE_FAN :: DvzVisualType
+pattern DVZ_VISUAL_TRIANGLE_FAN = DvzVisualType #{const DVZ_VISUAL_TRIANGLE_FAN}
+pattern DVZ_VISUAL_RECTANGLE :: DvzVisualType
+pattern DVZ_VISUAL_RECTANGLE = DvzVisualType #{const DVZ_VISUAL_RECTANGLE}
+pattern DVZ_VISUAL_MARKER :: DvzVisualType
+pattern DVZ_VISUAL_MARKER = DvzVisualType #{const DVZ_VISUAL_MARKER}
+pattern DVZ_VISUAL_SEGMENT :: DvzVisualType
+pattern DVZ_VISUAL_SEGMENT = DvzVisualType #{const DVZ_VISUAL_SEGMENT}
+pattern DVZ_VISUAL_ARROW :: DvzVisualType
+pattern DVZ_VISUAL_ARROW = DvzVisualType #{const DVZ_VISUAL_ARROW}
+pattern DVZ_VISUAL_PATH :: DvzVisualType
+pattern DVZ_VISUAL_PATH = DvzVisualType #{const DVZ_VISUAL_PATH}
+pattern DVZ_VISUAL_TEXT :: DvzVisualType
+pattern DVZ_VISUAL_TEXT = DvzVisualType #{const DVZ_VISUAL_TEXT}
+pattern DVZ_VISUAL_IMAGE :: DvzVisualType
+pattern DVZ_VISUAL_IMAGE = DvzVisualType #{const DVZ_VISUAL_IMAGE}
+pattern DVZ_VISUAL_IMAGE_CMAP :: DvzVisualType
+pattern DVZ_VISUAL_IMAGE_CMAP = DvzVisualType #{const DVZ_VISUAL_IMAGE_CMAP}
+pattern DVZ_VISUAL_DISC :: DvzVisualType
+pattern DVZ_VISUAL_DISC = DvzVisualType #{const DVZ_VISUAL_DISC}
+pattern DVZ_VISUAL_SECTOR :: DvzVisualType
+pattern DVZ_VISUAL_SECTOR = DvzVisualType #{const DVZ_VISUAL_SECTOR}
+pattern DVZ_VISUAL_MESH :: DvzVisualType
+pattern DVZ_VISUAL_MESH = DvzVisualType #{const DVZ_VISUAL_MESH}
+pattern DVZ_VISUAL_POLYGON :: DvzVisualType
+pattern DVZ_VISUAL_POLYGON = DvzVisualType #{const DVZ_VISUAL_POLYGON}
+pattern DVZ_VISUAL_PSLG :: DvzVisualType
+pattern DVZ_VISUAL_PSLG = DvzVisualType #{const DVZ_VISUAL_PSLG}
+pattern DVZ_VISUAL_HISTOGRAM :: DvzVisualType
+pattern DVZ_VISUAL_HISTOGRAM = DvzVisualType #{const DVZ_VISUAL_HISTOGRAM}
+pattern DVZ_VISUAL_AREA :: DvzVisualType
+pattern DVZ_VISUAL_AREA = DvzVisualType #{const DVZ_VISUAL_AREA}
+pattern DVZ_VISUAL_CANDLE :: DvzVisualType
+pattern DVZ_VISUAL_CANDLE = DvzVisualType #{const DVZ_VISUAL_CANDLE}
+pattern DVZ_VISUAL_GRAPH :: DvzVisualType
+pattern DVZ_VISUAL_GRAPH = DvzVisualType #{const DVZ_VISUAL_GRAPH}
+pattern DVZ_VISUAL_SURFACE :: DvzVisualType
+pattern DVZ_VISUAL_SURFACE = DvzVisualType #{const DVZ_VISUAL_SURFACE}
+pattern DVZ_VISUAL_VOLUME_SLICE :: DvzVisualType
+pattern DVZ_VISUAL_VOLUME_SLICE = DvzVisualType #{const DVZ_VISUAL_VOLUME_SLICE}
+pattern DVZ_VISUAL_VOLUME :: DvzVisualType
+pattern DVZ_VISUAL_VOLUME = DvzVisualType #{const DVZ_VISUAL_VOLUME}
+pattern DVZ_VISUAL_FAKE_SPHERE :: DvzVisualType
+pattern DVZ_VISUAL_FAKE_SPHERE = DvzVisualType #{const DVZ_VISUAL_FAKE_SPHERE}
+pattern DVZ_VISUAL_AXES_2D :: DvzVisualType
+pattern DVZ_VISUAL_AXES_2D = DvzVisualType #{const DVZ_VISUAL_AXES_2D}
+pattern DVZ_VISUAL_AXES_3D :: DvzVisualType
+pattern DVZ_VISUAL_AXES_3D = DvzVisualType #{const DVZ_VISUAL_AXES_3D}
+pattern DVZ_VISUAL_COLORMAP :: DvzVisualType
+pattern DVZ_VISUAL_COLORMAP = DvzVisualType #{const DVZ_VISUAL_COLORMAP}
+pattern DVZ_VISUAL_COUNT :: DvzVisualType
+pattern DVZ_VISUAL_COUNT = DvzVisualType #{const DVZ_VISUAL_COUNT}
+pattern DVZ_VISUAL_CUSTOM :: DvzVisualType
+pattern DVZ_VISUAL_CUSTOM = DvzVisualType #{const DVZ_VISUAL_CUSTOM}
+
+{-# COMPLETE DVZ_VISUAL_NONE,
+    DVZ_VISUAL_POINT,
+    DVZ_VISUAL_LINE,
+    DVZ_VISUAL_LINE_STRIP,
+    DVZ_VISUAL_TRIANGLE,
+    DVZ_VISUAL_TRIANGLE_STRIP,
+    DVZ_VISUAL_TRIANGLE_FAN,
+    DVZ_VISUAL_RECTANGLE,
+    DVZ_VISUAL_MARKER,
+    DVZ_VISUAL_SEGMENT,
+    DVZ_VISUAL_ARROW,
+    DVZ_VISUAL_PATH,
+    DVZ_VISUAL_TEXT,
+    DVZ_VISUAL_IMAGE,
+    DVZ_VISUAL_IMAGE_CMAP,
+    DVZ_VISUAL_DISC,
+    DVZ_VISUAL_SECTOR,
+    DVZ_VISUAL_MESH,
+    DVZ_VISUAL_POLYGON,
+    DVZ_VISUAL_PSLG,
+    DVZ_VISUAL_HISTOGRAM,
+    DVZ_VISUAL_AREA,
+    DVZ_VISUAL_CANDLE,
+    DVZ_VISUAL_GRAPH,
+    DVZ_VISUAL_SURFACE,
+    DVZ_VISUAL_VOLUME_SLICE,
+    DVZ_VISUAL_VOLUME,
+    DVZ_VISUAL_FAKE_SPHERE,
+    DVZ_VISUAL_AXES_2D,
+    DVZ_VISUAL_AXES_3D,
+    DVZ_VISUAL_COLORMAP,
+    DVZ_VISUAL_COUNT,
+    DVZ_VISUAL_CUSTOM
+    #-}
+
+newtype DvzPropType = DvzPropType { getDvzPropType :: CInt }
+
+pattern DVZ_PROP_NONE :: DvzPropType
+pattern DVZ_PROP_NONE = DvzPropType #{const DVZ_PROP_NONE}
+pattern DVZ_PROP_POS :: DvzPropType
+pattern DVZ_PROP_POS = DvzPropType #{const DVZ_PROP_POS}
+pattern DVZ_PROP_COLOR :: DvzPropType
+pattern DVZ_PROP_COLOR = DvzPropType #{const DVZ_PROP_COLOR}
+pattern DVZ_PROP_ALPHA :: DvzPropType
+pattern DVZ_PROP_ALPHA = DvzPropType #{const DVZ_PROP_ALPHA}
+pattern DVZ_PROP_COLORMAP :: DvzPropType
+pattern DVZ_PROP_COLORMAP = DvzPropType #{const DVZ_PROP_COLORMAP}
+pattern DVZ_PROP_MARKER_SIZE :: DvzPropType
+pattern DVZ_PROP_MARKER_SIZE = DvzPropType #{const DVZ_PROP_MARKER_SIZE}
+pattern DVZ_PROP_MARKER_TYPE :: DvzPropType
+pattern DVZ_PROP_MARKER_TYPE = DvzPropType #{const DVZ_PROP_MARKER_TYPE}
+pattern DVZ_PROP_ANGLE :: DvzPropType
+pattern DVZ_PROP_ANGLE = DvzPropType #{const DVZ_PROP_ANGLE}
+pattern DVZ_PROP_TEXT :: DvzPropType
+pattern DVZ_PROP_TEXT = DvzPropType #{const DVZ_PROP_TEXT}
+pattern DVZ_PROP_TEXT_SIZE :: DvzPropType
+pattern DVZ_PROP_TEXT_SIZE = DvzPropType #{const DVZ_PROP_TEXT_SIZE}
+pattern DVZ_PROP_GLYPH :: DvzPropType
+pattern DVZ_PROP_GLYPH = DvzPropType #{const DVZ_PROP_GLYPH}
+pattern DVZ_PROP_ANCHOR :: DvzPropType
+pattern DVZ_PROP_ANCHOR = DvzPropType #{const DVZ_PROP_ANCHOR}
+pattern DVZ_PROP_LINE_WIDTH :: DvzPropType
+pattern DVZ_PROP_LINE_WIDTH = DvzPropType #{const DVZ_PROP_LINE_WIDTH}
+pattern DVZ_PROP_MITER_LIMIT :: DvzPropType
+pattern DVZ_PROP_MITER_LIMIT = DvzPropType #{const DVZ_PROP_MITER_LIMIT}
+pattern DVZ_PROP_CAP_TYPE :: DvzPropType
+pattern DVZ_PROP_CAP_TYPE = DvzPropType #{const DVZ_PROP_CAP_TYPE}
+pattern DVZ_PROP_JOIN_TYPE :: DvzPropType
+pattern DVZ_PROP_JOIN_TYPE = DvzPropType #{const DVZ_PROP_JOIN_TYPE}
+pattern DVZ_PROP_TOPOLOGY :: DvzPropType
+pattern DVZ_PROP_TOPOLOGY = DvzPropType #{const DVZ_PROP_TOPOLOGY}
+pattern DVZ_PROP_LENGTH :: DvzPropType
+pattern DVZ_PROP_LENGTH = DvzPropType #{const DVZ_PROP_LENGTH}
+pattern DVZ_PROP_RANGE :: DvzPropType
+pattern DVZ_PROP_RANGE = DvzPropType #{const DVZ_PROP_RANGE}
+pattern DVZ_PROP_MARGIN :: DvzPropType
+pattern DVZ_PROP_MARGIN = DvzPropType #{const DVZ_PROP_MARGIN}
+pattern DVZ_PROP_NORMAL :: DvzPropType
+pattern DVZ_PROP_NORMAL = DvzPropType #{const DVZ_PROP_NORMAL}
+pattern DVZ_PROP_TEXCOORDS :: DvzPropType
+pattern DVZ_PROP_TEXCOORDS = DvzPropType #{const DVZ_PROP_TEXCOORDS}
+pattern DVZ_PROP_TEXCOEFS :: DvzPropType
+pattern DVZ_PROP_TEXCOEFS = DvzPropType #{const DVZ_PROP_TEXCOEFS}
+pattern DVZ_PROP_TRANSFER_X :: DvzPropType
+pattern DVZ_PROP_TRANSFER_X = DvzPropType #{const DVZ_PROP_TRANSFER_X}
+pattern DVZ_PROP_TRANSFER_Y :: DvzPropType
+pattern DVZ_PROP_TRANSFER_Y = DvzPropType #{const DVZ_PROP_TRANSFER_Y}
+pattern DVZ_PROP_LIGHT_POS :: DvzPropType
+pattern DVZ_PROP_LIGHT_POS = DvzPropType #{const DVZ_PROP_LIGHT_POS}
+pattern DVZ_PROP_LIGHT_PARAMS :: DvzPropType
+pattern DVZ_PROP_LIGHT_PARAMS = DvzPropType #{const DVZ_PROP_LIGHT_PARAMS}
+pattern DVZ_PROP_CLIP :: DvzPropType
+pattern DVZ_PROP_CLIP = DvzPropType #{const DVZ_PROP_CLIP}
+pattern DVZ_PROP_MODEL :: DvzPropType
+pattern DVZ_PROP_MODEL = DvzPropType #{const DVZ_PROP_MODEL}
+pattern DVZ_PROP_VIEW :: DvzPropType
+pattern DVZ_PROP_VIEW = DvzPropType #{const DVZ_PROP_VIEW}
+pattern DVZ_PROP_PROJ :: DvzPropType
+pattern DVZ_PROP_PROJ = DvzPropType #{const DVZ_PROP_PROJ}
+pattern DVZ_PROP_VIEWPORT :: DvzPropType
+pattern DVZ_PROP_VIEWPORT = DvzPropType #{const DVZ_PROP_VIEWPORT}
+pattern DVZ_PROP_TIME :: DvzPropType
+pattern DVZ_PROP_TIME = DvzPropType #{const DVZ_PROP_TIME}
+pattern DVZ_PROP_INDEX :: DvzPropType
+pattern DVZ_PROP_INDEX = DvzPropType #{const DVZ_PROP_INDEX}
+pattern DVZ_PROP_SCALE :: DvzPropType
+pattern DVZ_PROP_SCALE = DvzPropType #{const DVZ_PROP_SCALE}
+pattern DVZ_PROP_TRANSFORM :: DvzPropType
+pattern DVZ_PROP_TRANSFORM = DvzPropType #{const DVZ_PROP_TRANSFORM}
+
+{-# COMPLETE
+    DVZ_PROP_NONE
+  , DVZ_PROP_POS
+  , DVZ_PROP_COLOR
+  , DVZ_PROP_ALPHA
+  , DVZ_PROP_COLORMAP
+  , DVZ_PROP_MARKER_SIZE
+  , DVZ_PROP_MARKER_TYPE
+  , DVZ_PROP_ANGLE
+  , DVZ_PROP_TEXT
+  , DVZ_PROP_TEXT_SIZE
+  , DVZ_PROP_GLYPH
+  , DVZ_PROP_ANCHOR
+  , DVZ_PROP_LINE_WIDTH
+  , DVZ_PROP_MITER_LIMIT
+  , DVZ_PROP_CAP_TYPE
+  , DVZ_PROP_JOIN_TYPE
+  , DVZ_PROP_TOPOLOGY
+  , DVZ_PROP_LENGTH
+  , DVZ_PROP_RANGE
+  , DVZ_PROP_MARGIN
+  , DVZ_PROP_NORMAL
+  , DVZ_PROP_TEXCOORDS
+  , DVZ_PROP_TEXCOEFS
+  , DVZ_PROP_TRANSFER_X
+  , DVZ_PROP_TRANSFER_Y
+  , DVZ_PROP_LIGHT_POS
+  , DVZ_PROP_LIGHT_PARAMS
+  , DVZ_PROP_CLIP
+  , DVZ_PROP_MODEL
+  , DVZ_PROP_VIEW
+  , DVZ_PROP_PROJ
+  , DVZ_PROP_VIEWPORT
+  , DVZ_PROP_TIME
+  , DVZ_PROP_INDEX
+  , DVZ_PROP_SCALE
+  , DVZ_PROP_TRANSFORM #-}
+
+foreign import ccall dvz_visual_data_source :: DvzVisual -> DvzSourceType -> Word32 -> Word32 -> Word32 -> Word32 -> Ptr () -> IO ()
+
+foreign import capi safe "datoviz/datoviz.h"
+    dvz_visual_data :: DvzVisual -> DvzPropType -> Word32 -> Word32 -> Ptr () -> IO ()

--- a/src/Graphics/Datoviz/Vklite.hsc
+++ b/src/Graphics/Datoviz/Vklite.hsc
@@ -1,0 +1,29 @@
+module Graphics.Datoviz.Vklite where
+
+import Data.Word
+import Foreign.C.String
+import Foreign.C.Types
+import Foreign.Ptr
+
+import Graphics.Datoviz.App
+
+data C_DvzGpu
+
+newtype DvzGpu = DvzGpu { getDvzGpu :: Ptr C_DvzGpu }
+
+data C_DvzGraphics
+
+newtype DvzGraphics = DvzGraphics { getDvzGraphics :: Ptr C_DvzGraphics }
+
+foreign import ccall dvz_gpu_best :: DvzApp -> IO DvzGpu
+
+foreign import ccall dvz_graphics_shader :: DvzGraphics -> CInt -> CString -> IO ()
+
+foreign import ccall dvz_graphics_topology :: DvzGraphics -> CInt -> IO ()
+
+foreign import ccall dvz_graphics_vertex_binding :: DvzGraphics -> Word32 -> Word64 -> IO ()
+
+foreign import ccall dvz_graphics_vertex_attr :: DvzGraphics -> Word32 -> Word32 -> CInt -> Word64 -> IO ()
+
+foreign import ccall dvz_graphics_create :: DvzGraphics -> IO ()
+


### PR DESCRIPTION
This binds enough of the datoviz C Api to make a 'pure' Haskell version of the [standalone scene](https://datoviz.org/howto/standalone_scene/)

other notable changes
- Copy upstream file structure
- newtype wrapper on `linear.{V2, V3, V4}` for emulating c-typedefs
- Use CApiFFI for all new foreign imports