### PR TITLE
housekeeping(nix): pin nixpkgs to 23.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,15 +17,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675304987,
-        "narHash": "sha256-VvsHCaCjY9qi4O8kcLy1glynPeTOM+jDQKEy7P1KCsY=",
+        "lastModified": 1685865905,
+        "narHash": "sha256-XJZ/o17eOd2sEsGif+/MQBnfa2DKmndWgJyc7CWajFc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1602f4034c9d122a239f77c553a351a0624081f0",
+        "rev": "e7603eba51f2c7820c0a182c6bbb351181caa8e7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Almost raw Haskell bindings to datoviz.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -22,11 +22,11 @@
 
         datoviz-derivation =
           { stdenv, cglm, cmake, fetchFromGitHub, glfw, shaderc, vulkan-headers, vulkan-loader, zlib }:
-          stdenv.mkDerivation 
+          stdenv.mkDerivation
           {
              name = "datoviz";
              version = "0.0.1";
-             description = 
+             description =
                "High-performance GPU interactive scientific data visualization with Vulkan.";
              src = fetchFromGitHub ({
                  owner = "datoviz";


### PR DESCRIPTION
After upgrading from NixOS 22.11 to NixOS 23.05 I was unable to run the `standalone-canvas` example due to a driver version mismatch.

```bash
[spj@skamdart:~/skamdart/datoviz-hs]$ cabal run standalone-canvas
Build profile: -w ghc-9.2.4 -O1
In order, the following will be built (use -v for more details):
 - datoviz-hs-0.1.0.0 (lib) (first run)
 - datoviz-hs-0.1.0.0 (exe:standalone-canvas) (first run)
Configuring library for datoviz-hs-0.1.0.0..
Preprocessing library for datoviz-hs-0.1.0.0..
Building library for datoviz-hs-0.1.0.0..
[1 of 9] Compiling Graphics.Datoviz.App ( /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/App.hs, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/App.o, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/App.dyn_o )
[2 of 9] Compiling Graphics.Datoviz.Colormaps ( /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Colormaps.hs, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Colormaps.o, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Colormaps.dyn_o )
[3 of 9] Compiling Graphics.Datoviz.Panel ( /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Panel.hs, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Panel.o, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Panel.dyn_o )
[4 of 9] Compiling Graphics.Datoviz.Types ( src/Graphics/Datoviz/Types.hs, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Types.o, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Types.dyn_o )
[5 of 9] Compiling Graphics.Datoviz.Visuals ( /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Visuals.hs, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Visuals.o, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Visuals.dyn_o )
[6 of 9] Compiling Graphics.Datoviz.Vklite ( /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Vklite.hs, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Vklite.o, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Vklite.dyn_o )
[7 of 9] Compiling Graphics.Datoviz.Canvas ( /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Canvas.hs, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Canvas.o, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Canvas.dyn_o )
[8 of 9] Compiling Graphics.Datoviz.Scene ( /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Scene.hs, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Scene.o, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz/Scene.dyn_o )
[9 of 9] Compiling Graphics.Datoviz ( src/Graphics/Datoviz.hs, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz.o, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/build/Graphics/Datoviz.dyn_o )
Configuring executable 'standalone-canvas' for datoviz-hs-0.1.0.0..
Preprocessing executable 'standalone-canvas' for datoviz-hs-0.1.0.0..
Building executable 'standalone-canvas' for datoviz-hs-0.1.0.0..
[1 of 1] Compiling Main             ( examples/StandaloneCanvas.hs, /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/x/standalone-canvas/build/standalone-canvas/standalone-canvas-tmp/Main.o )
Linking /home/spj/skamdart/datoviz-hs/dist-newstyle/build/x86_64-linux/ghc-9.2.4/datoviz-hs-0.1.0.0/x/standalone-canvas/build/standalone-canvas/standalone-canvas ...
20:18:31.033 E     vklite_utils.h:0068: VkResult is ERROR_INCOMPATIBLE_DRIVER in /build/source/src/vklite_utils.h at line 68
Aborted (core dumped)
```

Did not dig any further than this before attempting to match nixpkgs and nixos version.

This seems to fix it